### PR TITLE
Test fix for the GitHub Actions Workflow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,3 +33,5 @@ replace (
 )
 
 replace github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.10.0
+
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0


### PR DESCRIPTION
Currently the GitHub Actions Workflow throws an error, while getting the go dependencies:

```
go: git.apache.org/thrift.git@v0.12.0: unknown revision v0.12.0
518
go: git.apache.org/thrift.git@v0.0.0-20180902110319-2566ecd5d999: git fetch -f origin refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in /home/runner/go/pkg/mod/cache/vcs/83dba939f95a790e497d565fc4418400145a1a514f955fa052f662d56e920c3e: exit status 128:
519
	fatal: unable to access 'https://git.apache.org/thrift.git/': Failed to connect to git.apache.org port 443: Connection timed out
520
go: error loading module requirements
521
##[error]Process completed with exit code 1.
```