### PR TITLE
Add support for KV Secrets Engine - Version 2

### DIFF
--- a/charts/vault-secrets-operator/templates/custom-resource-definition.yaml
+++ b/charts/vault-secrets-operator/templates/custom-resource-definition.yaml
@@ -42,10 +42,25 @@ spec:
             path:
               description: Path is the path of the corresponding secret in Vault.
               type: string
+            secretEngine:
+              description: SecretEngine specifies the type of the Vault secret engine
+                in which the secret is stored. Currently the 'KV Secrets Engine -
+                Version 1' and 'KV Secrets Engine - Version 2' are supported. The
+                value must be 'kv1' or 'kv2'. If the value is omitted or an other
+                values is used the Vault Secrets Operator will try to use the 'KV
+                Secrets Engine - Version 1'.
+              type: string
             type:
               description: Type is the type of the Kubernetes secret, which will be
                 created by the Vault Secrets Operator.
               type: string
+            version:
+              description: Version sets the version of the secret which should be
+                used. The version is only used if the SecretEngine is of type 'kv2'.
+                If the version is omitted the Operator uses the latest version of
+                the secret.
+              format: int64
+              type: integer
           required:
           - path
           - type

--- a/deploy/crds/ricoberger_v1alpha1_vaultsecret_cr.yaml
+++ b/deploy/crds/ricoberger_v1alpha1_vaultsecret_cr.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   keys:
     - foo
-  path: secrets/example-vaultsecret
+  path: kv1/example-vaultsecret
   type: Opaque

--- a/deploy/crds/ricoberger_v1alpha1_vaultsecret_crd.yaml
+++ b/deploy/crds/ricoberger_v1alpha1_vaultsecret_crd.yaml
@@ -51,6 +51,13 @@ spec:
               description: Type is the type of the Kubernetes secret, which will be
                 created by the Vault Secrets Operator.
               type: string
+            version:
+              description: Version sets the version of the secret which should be
+                used. The version is only used if the SecretEngine is of type 'kv2'.
+                If the version is omitted the Operator uses the latest version of
+                the secret.
+              format: int64
+              type: integer
           required:
           - path
           - type

--- a/deploy/crds/ricoberger_v1alpha1_vaultsecret_crd.yaml
+++ b/deploy/crds/ricoberger_v1alpha1_vaultsecret_crd.yaml
@@ -39,6 +39,14 @@ spec:
             path:
               description: Path is the path of the corresponding secret in Vault.
               type: string
+            secretEngine:
+              description: SecretEngine specifies the type of the Vault secret engine
+                in which the secret is stored. Currently the 'KV Secrets Engine -
+                Version 1' and 'KV Secrets Engine - Version 2' are supported. The
+                value must be 'kv1' or 'kv2'. If the value is omitted or an other
+                values is used the Vault Secrets Operator will try to use the 'KV
+                Secrets Engine - Version 1'.
+              type: string
             type:
               description: Type is the type of the Kubernetes secret, which will be
                 created by the Vault Secrets Operator.

--- a/pkg/apis/ricoberger/v1alpha1/vaultsecret_types.go
+++ b/pkg/apis/ricoberger/v1alpha1/vaultsecret_types.go
@@ -17,6 +17,12 @@ type VaultSecretSpec struct {
 	Keys []string `json:"keys,omitempty"`
 	// Path is the path of the corresponding secret in Vault.
 	Path string `json:"path"`
+	// SecretEngine specifies the type of the Vault secret engine in which the
+	// secret is stored. Currently the 'KV Secrets Engine - Version 1' and
+	// 'KV Secrets Engine - Version 2' are supported. The value must be 'kv1' or
+	// 'kv2'. If the value is omitted or an other values is used the Vault
+	// Secrets Operator will try to use the 'KV Secrets Engine - Version 1'.
+	SecretEngine string `json:"secretEngine,omitempty"`
 	// Type is the type of the Kubernetes secret, which will be created by the
 	// Vault Secrets Operator.
 	Type corev1.SecretType `json:"type"`

--- a/pkg/apis/ricoberger/v1alpha1/vaultsecret_types.go
+++ b/pkg/apis/ricoberger/v1alpha1/vaultsecret_types.go
@@ -26,6 +26,10 @@ type VaultSecretSpec struct {
 	// Type is the type of the Kubernetes secret, which will be created by the
 	// Vault Secrets Operator.
 	Type corev1.SecretType `json:"type"`
+	// Version sets the version of the secret which should be used. The version
+	// is only used if the SecretEngine is of type 'kv2'. If the version is
+	// omitted the Operator uses the latest version of the secret.
+	Version int `json:"version,omitempty"`
 }
 
 // VaultSecretStatus defines the observed state of VaultSecret

--- a/pkg/apis/ricoberger/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/ricoberger/v1alpha1/zz_generated.openapi.go
@@ -87,6 +87,13 @@ func schema_pkg_apis_ricoberger_v1alpha1_VaultSecretSpec(ref common.ReferenceCal
 							Format:      "",
 						},
 					},
+					"secretEngine": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SecretEngine specifies the type of the Vault secret engine in which the secret is stored. Currently the 'KV Secrets Engine - Version 1' and 'KV Secrets Engine - Version 2' are supported. The value must be 'kv1' or 'kv2'. If the value is omitted or an other values is used the Vault Secrets Operator will try to use the 'KV Secrets Engine - Version 1'.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"type": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Type is the type of the Kubernetes secret, which will be created by the Vault Secrets Operator.",

--- a/pkg/apis/ricoberger/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/ricoberger/v1alpha1/zz_generated.openapi.go
@@ -101,6 +101,13 @@ func schema_pkg_apis_ricoberger_v1alpha1_VaultSecretSpec(ref common.ReferenceCal
 							Format:      "",
 						},
 					},
+					"version": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Version sets the version of the secret which should be used. The version is only used if the SecretEngine is of type 'kv2'. If the version is omitted the Operator uses the latest version of the secret.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
 				Required: []string{"path", "type"},
 			},

--- a/pkg/controller/vaultsecret/vaultsecret_controller.go
+++ b/pkg/controller/vaultsecret/vaultsecret_controller.go
@@ -2,7 +2,6 @@ package vaultsecret
 
 import (
 	"context"
-	"fmt"
 
 	ricobergerv1alpha1 "github.com/ricoberger/vault-secrets-operator/pkg/apis/ricoberger/v1alpha1"
 	"github.com/ricoberger/vault-secrets-operator/pkg/vault"
@@ -99,10 +98,9 @@ func (r *ReconcileVaultSecret) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{}, err
 	}
 
-	reqLogger.Info(fmt.Sprintf("%#v", instance))
-	data, err := vault.GetSecret(instance.Spec.Path, instance.Spec.Keys)
+	data, err := vault.GetSecret(instance.Spec.SecretEngine, instance.Spec.Path, instance.Spec.Keys)
 	if err != nil {
-		reqLogger.Error(err, "Could not create secret")
+		reqLogger.Error(err, "Could get secret from vault")
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controller/vaultsecret/vaultsecret_controller.go
+++ b/pkg/controller/vaultsecret/vaultsecret_controller.go
@@ -98,7 +98,7 @@ func (r *ReconcileVaultSecret) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{}, err
 	}
 
-	data, err := vault.GetSecret(instance.Spec.SecretEngine, instance.Spec.Path, instance.Spec.Keys)
+	data, err := vault.GetSecret(instance.Spec.SecretEngine, instance.Spec.Path, instance.Spec.Keys, instance.Spec.Version)
 	if err != nil {
 		reqLogger.Error(err, "Could get secret from vault")
 		return reconcile.Result{}, nil


### PR DESCRIPTION
This PR closes #6 and add support for the KV Secrets Engine - Version 2. Therefor the structure of the CR changed. A field called `secretEngine` is added to specify which secret engine is used under the specified path. This PR adds also a `version` field, which allows to specify the version of a secret in a KV2 secret engine.

```yaml
apiVersion: ricoberger.de/v1alpha1
kind: VaultSecret
metadata:
  name: example-vaultsecret
spec:
  path: kv2/example-vaultsecret
  secretEngine: kv2
  type: Opaque
  version: 4
```

TODO:

- [x] Add possibility to specify version of the secret, when the KV2 secret engine is used
- [x] Update readme
- [x] Update Helm chart