### PR TITLE
Add support for nested secret values

### DIFF
--- a/pkg/controller/vaultsecret/vaultsecret_controller.go
+++ b/pkg/controller/vaultsecret/vaultsecret_controller.go
@@ -100,7 +100,7 @@ func (r *ReconcileVaultSecret) Reconcile(request reconcile.Request) (reconcile.R
 
 	data, err := vault.GetSecret(instance.Spec.SecretEngine, instance.Spec.Path, instance.Spec.Keys, instance.Spec.Version)
 	if err != nil {
-		reqLogger.Error(err, "Could get secret from vault")
+		reqLogger.Error(err, "Could not get secret from vault")
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -221,12 +221,16 @@ func GetSecret(secretEngine string, path string, keys []string, version int) (ma
 			case map[string]interface{}:
 				jsonString, err := json.Marshal(value)
 				if err != nil {
-					return nil, ErrParseSecretValue
+					return nil, err
 				}
 
 				data[key] = []byte(jsonString)
 			case string:
 				data[key] = []byte(value.(string))
+			case json.Number:
+				data[key] = []byte(value.(json.Number))
+			case bool:
+				data[key] = []byte(fmt.Sprintf("%t", value.(bool)))
 			default:
 				return nil, ErrParseSecretValue
 			}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -1,6 +1,7 @@
 package vault
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -37,6 +38,8 @@ var (
 	ErrParseSecret = errors.New("could not parse secret")
 	// ErrInvalidSecretData is our error if the returned secret data is invalid.
 	ErrInvalidSecretData = errors.New("invalid secret data")
+	// ErrParseSecretValue is our error if the returned secret data is invalid.
+	ErrParseSecretValue = errors.New("could not parse secret value")
 
 	// log is our customized logger.
 	log = logf.Log.WithName("vault")
@@ -208,12 +211,24 @@ func GetSecret(secretEngine string, path string, keys []string, version int) (ma
 	// Convert the secret data for a Kubernetes secret. We only add the provided
 	// keys to the resulting data or if there are no keys provided we add all
 	// keys of the secret.
+	// To support nested secret values we check the type of the value first. If
+	// The type is 'map[string]interface{}' we marshal the value to a JSON
+	// string, which can be used for the Kubernetes secret.
 	data := make(map[string][]byte)
 	for key, value := range secretData {
 		if len(keys) == 0 || contains(key, keys) {
-			if valueStr, ok := value.(string); ok {
-				log.Info(fmt.Sprintf("key: %s value: %s", key, valueStr))
-				data[key] = []byte(valueStr)
+			switch value.(type) {
+			case map[string]interface{}:
+				jsonString, err := json.Marshal(value)
+				if err != nil {
+					return nil, ErrParseSecretValue
+				}
+
+				data[key] = []byte(jsonString)
+			case string:
+				data[key] = []byte(value.(string))
+			default:
+				return nil, ErrParseSecretValue
 			}
 		}
 	}


### PR DESCRIPTION
In Vault you can have nested values for a secret to. So we need to check if the returned type from Vault is 'map[string]interface{}' and use the corresponding JSON string.

Resolves #9 