### PR TITLE
clarifies how to use the helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The **Vault Secrets Operator** creates a Kubernetes secret from Vault. The idea 
 
 ## Installation
 
-The Vault Secrets Operator can be installed via Helm. A list of all configurable values can be found [here](./charts/README.md).
+The Vault Secrets Operator can be installed via Helm. A list of all configurable values can be found [here](./charts/README.md). The chart assumes a vault server running at `http://vault:8200`, but can be overidden by specifying `--set vault.address=https://vault.example.com`
 
 ```sh
 helm repo add ricoberger https://ricoberger.github.io/helm-charts

--- a/charts/README.md
+++ b/charts/README.md
@@ -11,7 +11,7 @@
 | `nameOverride` | Expand the name of the chart. | `""` |
 | `fullnameOverride` | Override the name of the app. | `""` |
 | `environmentVars` | Pass environment variables from a secret to the containers. This must be used if you use the Token auth method of Vault. | `[]` |
-| `vault.address` | The address where Vault listen on (e.g. `http://vault.example.com`). | `""` |
+| `vault.address` | The address where Vault listen on (e.g. `http://vault.example.com`). | `"http://vault:8200"` |
 | `vault.authMethod` | The authentication method, which should be used by the operator. Can by `token` ([Token auth method](https://www.vaultproject.io/docs/auth/token.html)) or `kubernetes` ([Kubernetes auth method](https://www.vaultproject.io/docs/auth/kubernetes.html)). | `token` |
 | `vault.kubernetesPath` | If the Kubernetes auth method is used, this is the path where the Kubernetes auth method is enabled. | `auth/kubernetes` |
 | `vault.kubernetesRole` | The name of the role which is configured for the Kubernetes auth method. | `vault-secrets-operator` |

--- a/charts/vault-secrets-operator/Chart.yaml
+++ b/charts/vault-secrets-operator/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: Rico Berger
     url: https://ricoberger.de
 name: vault-secrets-operator
-version: 1.2.1
+version: 1.2.2

--- a/charts/vault-secrets-operator/Chart.yaml
+++ b/charts/vault-secrets-operator/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: Rico Berger
     url: https://ricoberger.de
 name: vault-secrets-operator
-version: 1.2.2
+version: 1.2.1

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -20,14 +20,16 @@ environmentVars: []
   #   secretName: vault-secrets-operator
   #   secretKey: VAULT_TOKEN_LEASE_DURATION
 
-# Set the address for vault and specify the authentication method for the operator.
-# Possible values are 'token' or 'kubernetes'. If the authentication method is 'kubernetes'
-# the Helm chart ensures that the Service Account included the needed rights. The default path
-# for the Kubernets Auth method is 'auth/kubernetes', if you enabled it under another path you
-# must change the 'kubernetesPath' value. You must also provide the role which should be used
-# for the authentication.
+# Set the address for vault (by default we assume you are running a dev
+# instance of vault in the same namespace as the operator) and specify the
+# authentication method for the operator.  Possible values are 'token' or
+# 'kubernetes'. If the authentication method is 'kubernetes' the Helm chart
+# ensures that the Service Account included the needed rights. The default path
+# for the Kubernets Auth method is 'auth/kubernetes', if you enabled it under
+# another path you must change the 'kubernetesPath' value. You must also
+# provide the role which should be used for the authentication.
 vault:
-  address: ""
+  address: "http://vault:8200"
   authMethod: token
   kubernetesPath: auth/kubernetes
   kubernetesRole: vault-secrets-operator


### PR DESCRIPTION
Adds a default vault.address and points out how to set the vault address in the main readme. Note, this increments the helm chart version