### PR TITLE
Add the possibility to read the Vault token from a mounted volume

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -7,12 +7,14 @@
 | `image.tag` | The tag of the Docker image which should be used. | `1.2.2` |
 | `image.pullPolicy` | The pull policy for the Docker image, | `IfNotPresent` |
 | `image.args` | Command-line arguments which should be passed to the container. This can be used to configure the logging. | `[]` |
+| `image.volumeMounts` | Mount additional volumns to the container. | `[]` |
 | `imagePullSecrets` | Secrets which can be used to pull the Docker image. | `[]` |
 | `nameOverride` | Expand the name of the chart. | `""` |
 | `fullnameOverride` | Override the name of the app. | `""` |
 | `environmentVars` | Pass environment variables from a secret to the containers. This must be used if you use the Token auth method of Vault. | `[]` |
 | `vault.address` | The address where Vault listen on (e.g. `http://vault.example.com`). | `"http://vault:8200"` |
 | `vault.authMethod` | The authentication method, which should be used by the operator. Can by `token` ([Token auth method](https://www.vaultproject.io/docs/auth/token.html)) or `kubernetes` ([Kubernetes auth method](https://www.vaultproject.io/docs/auth/kubernetes.html)). | `token` |
+| `vault.tokenPath` | Path to file with the Vault token if the used auth method is `token`. Can be used to read the token from a file and not from the  `VAULT_TOKEN` environment variable. | `""` |
 | `vault.kubernetesPath` | If the Kubernetes auth method is used, this is the path where the Kubernetes auth method is enabled. | `auth/kubernetes` |
 | `vault.kubernetesRole` | The name of the role which is configured for the Kubernetes auth method. | `vault-secrets-operator` |
 | `crd.create` | Create the custom resource definition. | `true` |
@@ -23,6 +25,7 @@
 | `service.metricsPort` | Port for the metrics. | `8383` |
 | `service.operatorMetricsPort` | Port for the operator metrics. | `8686` |
 | `resources` | Set resources for the operator. | `{}` |
+| `volumes` | Provide additional volumns for the container. | `[]` |
 | `nodeSelector` | Set a node selector. | `{}` |
 | `tolerations` | Set tolerations. | `[]` |
 | `affinity` | Set the affinity. | `{}` |

--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -52,6 +52,10 @@ spec:
             - name: opmetrics
               containerPort: 8686
               protocol: TCP
+          {{- with .Values.image.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -62,15 +66,19 @@ spec:
               port: opmetrics
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.affinity }}
+      {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}

--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -40,6 +40,8 @@ spec:
               value: {{ .Values.vault.address }}
             - name: VAULT_AUTH_METHOD
               value: {{ .Values.vault.authMethod }}
+            - name: VAULT_TOKEN_PATH
+              value: {{ .Values.vault.tokenPath }}
             - name: VAULT_KUBERNETES_PATH
               value: {{ .Values.vault.kubernetesPath }}
             - name: VAULT_KUBERNETES_ROLE

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -29,9 +29,12 @@ environmentVars: []
 # for the Kubernets Auth method is 'auth/kubernetes', if you enabled it under
 # another path you must change the 'kubernetesPath' value. You must also
 # provide the role which should be used for the authentication.
+# If the auth method is 'token' you can specify the 'tokenPath' to read the
+# Vault token from an mounted volumn instead of an environment variable.
 vault:
   address: "http://vault:8200"
   authMethod: token
+  tokenPath: ""
   kubernetesPath: auth/kubernetes
   kubernetesRole: vault-secrets-operator
 

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -5,6 +5,7 @@ image:
   tag: 1.2.2
   pullPolicy: IfNotPresent
   args: []
+  volumeMounts: []
 
 imagePullSecrets: []
 nameOverride: ""
@@ -60,6 +61,8 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+volumes: []
 
 nodeSelector: {}
 

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -104,7 +104,7 @@ func CreateClient() error {
 		}
 
 		if vaultTokenLeaseDuration == "" {
-			return ErrMissingVaultToken
+			return ErrMissingVaultTokenLeaseDuration
 		}
 
 		if tokenLeaseDuration, err = strconv.Atoi(vaultTokenLeaseDuration); err != nil {

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -56,6 +56,7 @@ func CreateClient() error {
 	vaultAddress := os.Getenv("VAULT_ADDRESS")
 	vaultAuthMethod := os.Getenv("VAULT_AUTH_METHOD")
 	vaultToken := os.Getenv("VAULT_TOKEN")
+	vaultTokenPath := os.Getenv("VAULT_TOKEN_PATH")
 	vaultTokenLeaseDuration := os.Getenv("VAULT_TOKEN_LEASE_DURATION")
 	vaultKubernetesPath := os.Getenv("VAULT_KUBERNETES_PATH")
 	vaultKubernetesRole := os.Getenv("VAULT_KUBERNETES_ROLE")
@@ -86,7 +87,20 @@ func CreateClient() error {
 		// token. If the values are empty or the lease duration could not be
 		// parsed we return an error.
 		if vaultToken == "" {
-			return ErrMissingVaultToken
+			// If the token is not passed via environment variable we check if,
+			// we can load the token from a file. Therefor a volume must be
+			// mounted to the container and the path to the token must be
+			// provided.
+			if vaultTokenPath == "" {
+				return ErrMissingVaultToken
+			}
+
+			t, err := ioutil.ReadFile(vaultTokenPath)
+			if err != nil {
+				return err
+			}
+
+			vaultToken = string(t)
 		}
 
 		if vaultTokenLeaseDuration == "" {


### PR DESCRIPTION
This PR adds the possibility to read the Vault token from a mounted volume. Therefor we introduce a new environment variable `VAULT_TOKEN_PATH` which should contain the path to a file with the Vault token. This variable is only processed if the authentication method is set to `token` and the `VAULT_TOKEN` environment variable is empty.

This PR also adjust the Helm chart to support the just described method to load a Vault token. To mount an additional volume to the created container you can set the `image.volumeMounts` and `volumes` values.

Closes #14 