### PR TITLE
Automatic Reconciliation

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -10,10 +10,10 @@ jobs:
     name: Release Docker Image
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.12
+    - name: Set up Go 1.13
       uses: actions/setup-go@v1
       with:
-        go-version: 1.12
+        go-version: 1.13
       id: go
 
     - name: Set up Operator SDK v0.10.0

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -7,10 +7,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.12
+    - name: Set up Go 1.13
       uses: actions/setup-go@v1
       with:
-        go-version: 1.12
+        go-version: 1.13
       id: go
 
     - name: Set up Operator SDK v0.10.0

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -10,10 +10,10 @@ jobs:
     name: Release Helm Chart
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.12
+    - name: Set up Go 1.13
       uses: actions/setup-go@v1
       with:
-        go-version: 1.12
+        go-version: 1.13
       id: go
 
     - name: Check out code into the Go module directory

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ metadata:
 type: Opaque
 ```
 
-The `spec.type` and `spec.keys` fields are handled in the same way for both versions of the KV secret engine. The `spec.version` field is only processed, when the secret is saved under a KVv2 secret engine.
+The `spec.type` and `spec.keys` fields are handled in the same way for both versions of the KV secret engine. The `spec.version` field is only processed, when the secret is saved under a KVv2 secret engine. If you specified the `VAULT_RECONCILIATION_TIME` environment variable with a value greater than `0` every secret is reconciled after the given time. This means, when you do not specify `spec.version`, the Kubernetes secret will be automatically updated if the Vault secret changes.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ export VAULT_ADDRESS=
 export VAULT_AUTH_METHOD=token
 export VAULT_TOKEN=
 export VAULT_TOKEN_LEASE_DURATION=
+export VAULT_RECONCILIATION_TIME=
 ```
 
 Run the operator locally with the default Kubernetes config file present at `$HOME/.kube/config`:

--- a/charts/README.md
+++ b/charts/README.md
@@ -17,6 +17,7 @@
 | `vault.tokenPath` | Path to file with the Vault token if the used auth method is `token`. Can be used to read the token from a file and not from the  `VAULT_TOKEN` environment variable. | `""` |
 | `vault.kubernetesPath` | If the Kubernetes auth method is used, this is the path where the Kubernetes auth method is enabled. | `auth/kubernetes` |
 | `vault.kubernetesRole` | The name of the role which is configured for the Kubernetes auth method. | `vault-secrets-operator` |
+| `vault.reconciliationTime` | The time after which the reconcile function for the CR is rerun. If the value is 0, automatic reconciliation is skipped. | `0` |
 | `crd.create` | Create the custom resource definition. | `true` |
 | `rbac.create` | Create the cluster role and cluster role bindings. | `true` |
 | `serviceAccount.create` | Create the service account. | `true` |

--- a/charts/vault-secrets-operator/templates/custom-resource-definition.yaml
+++ b/charts/vault-secrets-operator/templates/custom-resource-definition.yaml
@@ -57,7 +57,9 @@ spec:
               description: Version sets the version of the secret which should be
                 used. The version is only used if the KVv2 secret engine is used.
                 If the version is omitted the Operator uses the latest version of
-                the secret.
+                the secret. If the version omitted and the VAULT_RECONCILIATION_TIME
+                environment variable is set, the Kubernetes secret will be updated
+                if the Vault secret changes.
               format: int64
               type: integer
           required:

--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -46,6 +46,8 @@ spec:
               value: {{ .Values.vault.kubernetesPath }}
             - name: VAULT_KUBERNETES_ROLE
               value: {{ .Values.vault.kubernetesRole }}
+            - name: VAULT_RECONCILIATION_TIME
+              value: {{ .Values.vault.reconciliationTime }}
             {{- include "vault-secrets-operator.environmentVars" .Values | nindent 12 }}
           ports:
             - name: metrics

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -30,7 +30,10 @@ environmentVars: []
 # another path you must change the 'kubernetesPath' value. You must also
 # provide the role which should be used for the authentication.
 # If the auth method is 'token' you can specify the 'tokenPath' to read the
-# Vault token from an mounted volumn instead of an environment variable.
+# Vault token from a mounted volume instead of an environment variable.
+# The reconciliationTime value determines after which time the Vault secret is
+# processed again. This can be used to update a the Kubernetes secret, when the
+# Vault secret changes. A value of 0 will disable the automatic update.
 vault:
   address: "http://vault:8200"
   authMethod: token

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -37,6 +37,7 @@ vault:
   tokenPath: ""
   kubernetesPath: auth/kubernetes
   kubernetesRole: vault-secrets-operator
+  reconciliationTime: 0
 
 crd:
   create: true

--- a/deploy/crds/ricoberger_v1alpha1_vaultsecret_crd.yaml
+++ b/deploy/crds/ricoberger_v1alpha1_vaultsecret_crd.yaml
@@ -54,7 +54,9 @@ spec:
               description: Version sets the version of the secret which should be
                 used. The version is only used if the KVv2 secret engine is used.
                 If the version is omitted the Operator uses the latest version of
-                the secret.
+                the secret. If the version omitted and the VAULT_RECONCILIATION_TIME
+                environment variable is set, the Kubernetes secret will be updated
+                if the Vault secret changes.
               format: int64
               type: integer
           required:

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/ricoberger/vault-secrets-operator
 
 require (
-	github.com/NYTimes/gziphandler v1.0.1 // indirect
 	github.com/go-openapi/spec v0.19.0
 	github.com/hashicorp/vault/api v1.0.4
 	github.com/operator-framework/operator-sdk v0.10.1-0.20190820174346-abac23c897b8
@@ -34,4 +33,4 @@ replace (
 
 replace github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.10.0
 
-replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,7 @@ github.com/dgrijalva/jwt-go v0.0.0-20160705203006-01aeca54ebda/go.mod h1:E3ru+11
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/distribution v2.6.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/distribution v2.7.0+incompatible h1:neUDAlf3wX6Ml4HdqTrbcOHXtfRN0TFIwt6YFL7N9RU=
 github.com/docker/distribution v2.7.0+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v0.0.0-20180612054059-a9fbbdc8dd87/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
@@ -144,6 +145,7 @@ github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/glog v0.0.0-20141105023935-44145f04b68c/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20180924190550-6f2cf27854a4/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20181024230925-c65c006176ff/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -305,7 +307,9 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.4.2-0.20180831124310-ae19f1b56d53/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3 h1:RE1xgDvH7imwFD45h+u2SgIfERHlS2yNG4DObb5BSKU=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
+github.com/openshift/origin v0.0.0-20160503220234-8f127d736703 h1:KLVRXtjLhZHVtrcdnuefaI2Bf182EEiTfEVDHokoyng=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/openzipkin/zipkin-go v0.1.3/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
@@ -578,6 +582,7 @@ k8s.io/apiextensions-apiserver v0.0.0-20190228180357-d002e88f6236/go.mod h1:Ixke
 k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628 h1:UYfHH+KEF88OTg+GojQUwFTNxbxwmoktLwutUzR0GPg=
 k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/apiserver v0.0.0-20181026151315-13cfe3978170/go.mod h1:6bqaTSOSJavUIXUtfaR9Os9JtTCm8ZqH2SUl2S60C4w=
+k8s.io/apiserver v0.0.0-20181213151703-3ccfe8365421 h1:NyOpnIh+7SLvC05NGCIXF9c4KhnkTZQE2SxF+m9otww=
 k8s.io/apiserver v0.0.0-20181213151703-3ccfe8365421/go.mod h1:6bqaTSOSJavUIXUtfaR9Os9JtTCm8ZqH2SUl2S60C4w=
 k8s.io/cli-runtime v0.0.0-20181213153952-835b10687cb6/go.mod h1:qWnH3/b8sp/l7EvlDh7ulDU3UWA4P4N1NFbEEP791tM=
 k8s.io/client-go v0.0.0-20190228174230-b40b2a5939e4 h1:aE8wOCKuoRs2aU0OP/Rz8SXiAB0FTTku3VtGhhrkSmc=
@@ -603,7 +608,10 @@ k8s.io/kube-openapi v0.0.0-20190603182131-db7b694dc208/go.mod h1:nfDlWeOsu3pUf4y
 k8s.io/kube-state-metrics v1.6.0 h1:6wkxiTPTZ4j+LoMWuT+rZ+OlUWswktzXs5yHmggmAZ0=
 k8s.io/kube-state-metrics v1.6.0/go.mod h1:84+q9aGVQPzXYGgtvyhZr/fSI6BdLsbPWXn37RASc9k=
 k8s.io/kubernetes v1.11.7-beta.0.0.20181219023948-b875d52ea96d/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
+k8s.io/kubernetes v1.11.8-beta.0.0.20190124204751-3a10094374f2 h1:CzIOMOEjH+sQw35LY1Gl0jwthkyOojzaq2HIeYZYOrM=
 k8s.io/kubernetes v1.11.8-beta.0.0.20190124204751-3a10094374f2/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
+k8s.io/kubernetes v1.16.1 h1:5Ys1P0p+OkGMq+/RQWa3/gs2hlGfaNkVPsVY+vyZWqQ=
+k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7 h1:8r+l4bNWjRlsFYlQJnKJ2p7s1YQPj4XyXiJVqDHRx7c=
 k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
 sigs.k8s.io/controller-runtime v0.1.12 h1:ovDq28E64PeY1yR+6H7DthakIC09soiDCrKvfP2tPYo=
 sigs.k8s.io/controller-runtime v0.1.12/go.mod h1:HFAYoOh6XMV+jKF1UjFwrknPbowfyHEHHRdJMf2jMX8=

--- a/pkg/apis/ricoberger/v1alpha1/vaultsecret_types.go
+++ b/pkg/apis/ricoberger/v1alpha1/vaultsecret_types.go
@@ -28,7 +28,9 @@ type VaultSecretSpec struct {
 	Type corev1.SecretType `json:"type"`
 	// Version sets the version of the secret which should be used. The version
 	// is only used if the KVv2 secret engine is used. If the version is
-	// omitted the Operator uses the latest version of the secret.
+	// omitted the Operator uses the latest version of the secret. If the version
+	// omitted and the VAULT_RECONCILIATION_TIME environment variable is set, the
+	// Kubernetes secret will be updated if the Vault secret changes.
 	Version int `json:"version,omitempty"`
 }
 

--- a/pkg/apis/ricoberger/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/ricoberger/v1alpha1/zz_generated.openapi.go
@@ -103,7 +103,7 @@ func schema_pkg_apis_ricoberger_v1alpha1_VaultSecretSpec(ref common.ReferenceCal
 					},
 					"version": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Version sets the version of the secret which should be used. The version is only used if the KVv2 secret engine is used. If the version is omitted the Operator uses the latest version of the secret.",
+							Description: "Version sets the version of the secret which should be used. The version is only used if the KVv2 secret engine is used. If the version is omitted the Operator uses the latest version of the secret. If the version omitted and the VAULT_RECONCILIATION_TIME environment variable is set, the Kubernetes secret will be updated if the Vault secret changes.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},

--- a/pkg/controller/vaultsecret/vaultsecret_controller.go
+++ b/pkg/controller/vaultsecret/vaultsecret_controller.go
@@ -101,8 +101,9 @@ func (r *ReconcileVaultSecret) Reconcile(request reconcile.Request) (reconcile.R
 
 	data, err := vault.GetSecret(instance.Spec.SecretEngine, instance.Spec.Path, instance.Spec.Keys, instance.Spec.Version)
 	if err != nil {
+		// Error while getting the secret from Vault - requeue the request.
 		reqLogger.Error(err, "Could not get secret from vault")
-		return reconcile.Result{}, nil
+		return reconcile.Result{}, err
 	}
 
 	// Set reconciliation if the vault-secret does not specify a version.


### PR DESCRIPTION
Add automatic reconciliation to update secrets without a version number in the CR. Once merged this resolves #16.

TODO:

- [x] Add the new environment variable `VAULT_RECONCILIATION_TIME` as value to the Helm chart.
- [x] Adjust the documentation.
- [x] Look deeper into:
  - Delete k8s secret if the corresponding Vault secret was deleted
  - Protect k8s secret from manual edits