### PR TITLE
quoting numeric value

### DIFF
--- a/charts/vault-secrets-operator/Chart.yaml
+++ b/charts/vault-secrets-operator/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: Rico Berger
     url: https://ricoberger.de
 name: vault-secrets-operator
-version: 1.3.0
+version: 1.3.1

--- a/charts/vault-secrets-operator/Chart.yaml
+++ b/charts/vault-secrets-operator/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: Rico Berger
     url: https://ricoberger.de
 name: vault-secrets-operator
-version: 1.3.1
+version: 1.3.0

--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
             - name: VAULT_KUBERNETES_ROLE
               value: {{ .Values.vault.kubernetesRole }}
             - name: VAULT_RECONCILIATION_TIME
-              value: {{ .Values.vault.reconciliationTime }}
+              value: {{ .Values.vault.reconciliationTime | quote }}
             {{- include "vault-secrets-operator.environmentVars" .Values | nindent 12 }}
           ports:
             - name: metrics

--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -37,15 +37,15 @@ spec:
             - name: OPERATOR_NAME
               value: "vault-secrets-operator"
             - name: VAULT_ADDRESS
-              value: {{ .Values.vault.address }}
+              value: {{ .Values.vault.address | quote }}
             - name: VAULT_AUTH_METHOD
-              value: {{ .Values.vault.authMethod }}
+              value: {{ .Values.vault.authMethod | quote }}
             - name: VAULT_TOKEN_PATH
-              value: {{ .Values.vault.tokenPath }}
+              value: {{ .Values.vault.tokenPath | quote }}
             - name: VAULT_KUBERNETES_PATH
-              value: {{ .Values.vault.kubernetesPath }}
+              value: {{ .Values.vault.kubernetesPath | quote }}
             - name: VAULT_KUBERNETES_ROLE
-              value: {{ .Values.vault.kubernetesRole }}
+              value: {{ .Values.vault.kubernetesRole | quote }}
             - name: VAULT_RECONCILIATION_TIME
               value: {{ .Values.vault.reconciliationTime | quote }}
             {{- include "vault-secrets-operator.environmentVars" .Values | nindent 12 }}


### PR DESCRIPTION
Attempting to install chart 1.3.0 with vault.reconciliationTime set to some value (in my case, `300`) results in a helm deployment error:

```
helm chart v1.EnvVar.Value: ReadString: expects \\\" or n, but found 3
```

Based on [this issue](https://github.com/helm/helm/issues/4775) it seems that numeric ENV values need to be quoted, hence this PR.