### PR TITLE
Add vaule to set deployment strategy to Helm chart

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -3,6 +3,7 @@
 | Value | Description | Default |
 | ----- | ----------- | ------- |
 | `replicaCount` | Number of replications which should be created. | `1` |
+| `deploymentStrategy` | Deployment strategy which should be used. | `{}` |
 | `image.repository` | The repository of the Docker image. | `ricoberger/vault-secrets-operator` |
 | `image.tag` | The tag of the Docker image which should be used. | `1.3.1` |
 | `image.pullPolicy` | The pull policy for the Docker image, | `IfNotPresent` |

--- a/charts/vault-secrets-operator/templates/_helpers.tpl
+++ b/charts/vault-secrets-operator/templates/_helpers.tpl
@@ -63,9 +63,9 @@ Inject extra environment variables populated by secrets, if populated.
 {{- range .environmentVars }}
 - name: {{ .envName }}
   valueFrom:
-   secretKeyRef:
-     name: {{ .secretName }}
-     key: {{ .secretKey }}
+    secretKeyRef:
+      name: {{ .secretName }}
+      key: {{ .secretKey }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
 {{ include "vault-secrets-operator.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- with .Values.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "vault-secrets-operator.name" . }}
@@ -16,10 +20,10 @@ spec:
         app.kubernetes.io/name: {{ include "vault-secrets-operator.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-    {{- with .Values.imagePullSecrets }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
       serviceAccountName: {{ template "vault-secrets-operator.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -1,4 +1,5 @@
 replicaCount: 1
+deploymentStrategy: {}
 
 image:
   repository: ricoberger/vault-secrets-operator


### PR DESCRIPTION
It is now possible to specify the deployment strategy which should be used for the deployment of the operator.

Currently there seems to be a bug in the operator, which cause problems during an update. Therefor it is recommended to set the strategy type to recreate if a replication count of one is used:

```yaml
deploymentStrategy:
  type: Recreate
```