### PR TITLE
Add support for binary data stored in vault

### DIFF
--- a/charts/vault-secrets-operator/templates/custom-resource-definition.yaml
+++ b/charts/vault-secrets-operator/templates/custom-resource-definition.yaml
@@ -62,6 +62,14 @@ spec:
                 if the Vault secret changes.
               format: int64
               type: integer
+            isBinary:
+              description: isBinary is a flag indicates if data stored in vault is 
+                binary data. Since vault does not store binary data natively, 
+                the binary data is stored as base64 encoded. However, same data get encoded
+                again when operator stored them as secret in k8s which caused the data to 
+                get double encoded. This flag will skip the base64 encode which is needed 
+                for string data to avoid the double encode problem.
+              type: boolean
           required:
           - path
           - type

--- a/deploy/crds/ricoberger_v1alpha1_vaultsecret_crd.yaml
+++ b/deploy/crds/ricoberger_v1alpha1_vaultsecret_crd.yaml
@@ -59,6 +59,14 @@ spec:
                 if the Vault secret changes.
               format: int64
               type: integer
+            isBinary:
+              description: isBinary is a flag indicates if data stored in vault is 
+                binary data. Since vault does not store binary data natively, 
+                the binary data is stored as base64 encoded. However, same data get encoded
+                again when operator stored them as secret in k8s which caused the data to 
+                get double encoded. This flag will skip the base64 encode which is needed 
+                for string data to avoid the double encode problem.
+              type: boolean
           required:
           - path
           - type

--- a/pkg/apis/ricoberger/v1alpha1/vaultsecret_types.go
+++ b/pkg/apis/ricoberger/v1alpha1/vaultsecret_types.go
@@ -32,6 +32,13 @@ type VaultSecretSpec struct {
 	// omitted and the VAULT_RECONCILIATION_TIME environment variable is set, the
 	// Kubernetes secret will be updated if the Vault secret changes.
 	Version int `json:"version,omitempty"`
+	// isBinary is a flag indicates if data stored in vault is
+	// binary data. Since vault does not store binary data natively,
+	// the binary data is stored as base64 encoded. However, same data get encoded
+	// again when operator stored them as secret in k8s which caused the data to
+	// get double encoded. This flag will skip the base64 encode which is needed
+	// for string data to avoid the double encode problem.
+	IsBinary bool `json:"isBinary,omitempty"`
 }
 
 // VaultSecretStatus defines the observed state of VaultSecret

--- a/pkg/apis/ricoberger/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/ricoberger/v1alpha1/zz_generated.openapi.go
@@ -108,6 +108,13 @@ func schema_pkg_apis_ricoberger_v1alpha1_VaultSecretSpec(ref common.ReferenceCal
 							Format:      "int32",
 						},
 					},
+					"isBinary": {
+						SchemaProps: spec.SchemaProps{
+							Description: "isBinary is a flag indicates if data stored in vault is binary data. This flag will skip the base64 encode which is needed for string data to avoid the double encode problem.",
+							Type:        []string{"bool"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"path", "type"},
 			},

--- a/pkg/controller/vaultsecret/vaultsecret_controller.go
+++ b/pkg/controller/vaultsecret/vaultsecret_controller.go
@@ -95,6 +95,7 @@ func (r *ReconcileVaultSecret) Reconcile(request reconcile.Request) (reconcile.R
 
 	// Fetch the VaultSecret instance
 	instance := &ricobergerv1alpha1.VaultSecret{}
+
 	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -107,7 +108,7 @@ func (r *ReconcileVaultSecret) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{}, err
 	}
 
-	data, err := vault.GetSecret(instance.Spec.SecretEngine, instance.Spec.Path, instance.Spec.Keys, instance.Spec.Version)
+	data, err := vault.GetSecret(instance.Spec.SecretEngine, instance.Spec.Path, instance.Spec.Keys, instance.Spec.Version, instance.Spec.IsBinary)
 	if err != nil {
 		// Error while getting the secret from Vault - requeue the request.
 		reqLogger.Error(err, "Could not get secret from vault")

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -230,7 +230,6 @@ func GetSecret(secretEngine string, path string, keys []string, version int, isB
 			return nil, ErrParseSecret
 		}
 	}
-	log.Info("GetSecret: Get data from vault", "secretData is ", secretData)
 
 	// Convert the secret data for a Kubernetes secret. We only add the provided
 	// keys to the resulting data or if there are no keys provided we add all
@@ -251,6 +250,9 @@ func GetSecret(secretEngine string, path string, keys []string, version int, isB
 			case string:
 				if isBinary {
 					data[key], err = b64.StdEncoding.DecodeString(value.(string))
+					if err != nil {
+						return nil, err
+					}
 				} else {
 					data[key] = []byte(value.(string))
 				}
@@ -263,8 +265,6 @@ func GetSecret(secretEngine string, path string, keys []string, version int, isB
 			}
 		}
 	}
-
-	log.Info("GetSecret end of switch: value got type of map !!!!!!!", "data is ", data)
 
 	// If the data map is empty we return an error. This can happend, if the
 	// secret which was retrieved from Vault is under a KVv2 secrets engine, but

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -1,17 +1,17 @@
 package vault
 
 import (
+	b64 "encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/vault/api"
 	"io/ioutil"
 	"net/http"
 	"os"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"strconv"
 	"time"
-
-	"github.com/hashicorp/vault/api"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var (
@@ -184,7 +184,7 @@ func RenewToken() {
 }
 
 // GetSecret returns the value for a given secret.
-func GetSecret(secretEngine string, path string, keys []string, version int) (map[string][]byte, error) {
+func GetSecret(secretEngine string, path string, keys []string, version int, isBinary bool) (map[string][]byte, error) {
 	// Get the secret for the given path and return the secret data.
 	log.Info(fmt.Sprintf("Read secret %s", path))
 
@@ -230,6 +230,7 @@ func GetSecret(secretEngine string, path string, keys []string, version int) (ma
 			return nil, ErrParseSecret
 		}
 	}
+	log.Info("GetSecret: Get data from vault", "secretData is ", secretData)
 
 	// Convert the secret data for a Kubernetes secret. We only add the provided
 	// keys to the resulting data or if there are no keys provided we add all
@@ -246,10 +247,13 @@ func GetSecret(secretEngine string, path string, keys []string, version int) (ma
 				if err != nil {
 					return nil, err
 				}
-
 				data[key] = []byte(jsonString)
 			case string:
-				data[key] = []byte(value.(string))
+				if isBinary {
+					data[key], err = b64.StdEncoding.DecodeString(value.(string))
+				} else {
+					data[key] = []byte(value.(string))
+				}
 			case json.Number:
 				data[key] = []byte(value.(json.Number))
 			case bool:
@@ -260,6 +264,8 @@ func GetSecret(secretEngine string, path string, keys []string, version int) (ma
 		}
 	}
 
+	log.Info("GetSecret end of switch: value got type of map !!!!!!!", "data is ", data)
+
 	// If the data map is empty we return an error. This can happend, if the
 	// secret which was retrieved from Vault is under a KVv2 secrets engine, but
 	// the secret engine was not provided in the cr for the secret. Then the
@@ -267,7 +273,6 @@ func GetSecret(secretEngine string, path string, keys []string, version int) (ma
 	if len(data) == 0 {
 		return nil, ErrInvalidSecretData
 	}
-
 	return data, nil
 }
 


### PR DESCRIPTION
Hello Rico,
First of all, I would like to thank you for creating such a useful project which helps to bridge the gap between vault and k8s. Great work!
I am currently facing some issues with binary data using the operator which I made some change and would like to contribute back.

**Issue**
The issue that we are currently facing is the binary data that get stored in the vault. The current vault does not support binary data storage and the caller need to encode it in base64 (https://github.com/hashicorp/vault/issues/1423#issuecomment-219525845). When the operator gets the data from the vault and treat it as the string type and encode it again (which is the right thing to do). The data ends up gets encoded twice.

**Purposed solution**
The purposed solution is to add a flag int eh CDR to indicate the data is encoded binary data skip the encoding. It has been implemented as this PR. Can you take a look and let me know if you have any feedback?