### PR TITLE
Fix readiness and liveness probes

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -25,6 +25,7 @@
 | `serviceAccount.create` | Create the service account. | `true` |
 | `serviceAccount.name` | The name of the service account, which should be created/used by the operator. | `vault-secrets-operator` |
 | `service.type` | Type of the service, whiche should be created. | `ClusterIP` |
+| `service.httpPort` | Port for the HTTP server for readiness and liveness probes. | `8080` |
 | `service.metricsPort` | Port for the metrics. | `8383` |
 | `service.operatorMetricsPort` | Port for the operator metrics. | `8686` |
 | `resources` | Set resources for the operator. | `{}` |

--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -54,6 +54,9 @@ spec:
               value: {{ .Values.vault.reconciliationTime | quote }}
             {{- include "vault-secrets-operator.environmentVars" .Values | nindent 12 }}
           ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
             - name: metrics
               containerPort: 8383
               protocol: TCP
@@ -66,12 +69,12 @@ spec:
           {{- end }}
           livenessProbe:
             httpGet:
-              path: /healthz
-              port: opmetrics
+              path: /livenessProbe
+              port: http
           readinessProbe:
             httpGet:
-              path: /healthz
-              port: opmetrics
+              path: /readinessProbe
+              port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.volumes }}

--- a/charts/vault-secrets-operator/templates/service.yaml
+++ b/charts/vault-secrets-operator/templates/service.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
+    - port: {{ .Values.service.httpPort }}
+      targetPort: http
+      protocol: TCP
+      name: http
     - port: {{ .Values.service.metricsPort }}
       targetPort: metrics
       protocol: TCP

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -59,6 +59,7 @@ serviceAccount:
 
 service:
   type: ClusterIP
+  httpPort: 8080
   metricsPort: 8383
   operatorMetricsPort: 8686
 

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -168,6 +168,17 @@ func CreateClient() error {
 	return nil
 }
 
+// LookupToken displays information about a token. It's mainly used for the
+// readiness probe of the operator.
+func LookupToken() error {
+	_, err := client.Auth().Token().Lookup(client.Token())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // RenewToken renews the provided token after the half of the lease duration is
 // passed.
 func RenewToken() {


### PR DESCRIPTION
The error in issue #22 was caused by the readiness and liveness probes. These probes checks the `/healthz` endpoint of the CR metrics endpoint which isn't available in the case of the described error.

Now we are starting another HTTP server which implements more useful readiness and liveness endpoints. This should fix #22.