### PR TITLE
Use LookupSelf instead of Lookup function

### DIFF
--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -171,7 +171,7 @@ func CreateClient() error {
 // LookupToken displays information about a token. It's mainly used for the
 // readiness probe of the operator.
 func LookupToken() error {
-	_, err := client.Auth().Token().Lookup(client.Token())
+	_, err := client.Auth().Token().LookupSelf()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Use the LookupSelf function instead of the Lookup function. The Lookup
function requires more rights, but these rights are not needed for all
other operations of the operator.