### PR TITLE
Allow custom certificates

### DIFF
--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -315,10 +315,11 @@ func contains(key string, keys []string) bool {
 func createTLSConfig(caCert, clientCert, clientKey, skipVerify, tlsServerName string) (*tls.Config, error) {
 	tlsConfig := &tls.Config{
 		MinVersion: tls.VersionTLS12,
-		RootCAs: x509.NewCertPool(),
 	}
 
 	if caCert != "" {
+		tlsConfig.RootCAs = x509.NewCertPool()
+
 		if !tlsConfig.RootCAs.AppendCertsFromPEM([]byte(caCert)) {
 			return nil, ErrNoCertsFound
 		}


### PR DESCRIPTION
This closes #27. The certificate can be passed via environment variable to the operator. The following environment variable are introduced:

- `VAULT_CACERT`:  CA certificate to verify the Vault server's SSL certificate.
- `VAULT_CLIENT_CERT`: CA certificate to use for TLS authentication to the Vault server. 
- `VAULT_CLIENT_KEY`: Private key matching the client certificate from `VAULT_CLIENT_CERT `.
- `VAULT_SKIP_VERIFY`: Disable verification of TLS certificates.
- `VAULT_TLS_SERVER_NAME`: Name to use as the SNI host when connecting via TLS.

The environment variables can be set as follows in the Helm chart:

```yaml
environmentVars:
  - envName: VAULT_CACERT
    secretName: vault-secrets-operator-tls
    secretKey: VAULT_CACERT
  - envName: VAULT_CLIENT_CERT
    secretName: vault-secrets-operator-tls
    secretKey: VAULT_CLIENT_CERT
  - envName: VAULT_CLIENT_KEY
    secretName: vault-secrets-operator-tls
    secretKey: VAULT_CLIENT_KEY
```

The corresponding secret `vault-secrets-operator-tls` looks as follows:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: vault-secrets-operator-tls
data:
  VAULT_CACERT: ...
  VAULT_CLIENT_CERT: ...
  VAULT_CLIENT_KEY: ...
type: Opaque
```