### PR TITLE
Adding support for label and annotation inheritance

### DIFF
--- a/pkg/controller/vaultsecret/vaultsecret_controller.go
+++ b/pkg/controller/vaultsecret/vaultsecret_controller.go
@@ -155,12 +155,20 @@ func newSecretForCR(cr *ricobergerv1alpha1.VaultSecret, data map[string][]byte) 
 	labels := map[string]string{
 		"created-by": "vault-secrets-operator",
 	}
+	for k, v := range cr.ObjectMeta.Labels{
+		labels[k] = v
+	}
+	annotations := map[string]string{}
+	for k, v := range cr.ObjectMeta.Annotations{
+		annotations[k] = v
+	}
 
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
 			Namespace: cr.Namespace,
 			Labels:    labels,
+			Annotations: annotations,
 		},
 		Data: data,
 		Type: cr.Spec.Type,


### PR DESCRIPTION
We are using vault secrets operator to sync our secrets and would like to start using
https://jenkinsci.github.io/kubernetes-credentials-provider-plugin/examples/
to automatically discovery secrets with our labels/annotations. For this, it would be required that labels and annotations can be propagated from VaultSecrets object to created secret.