### PR TITLE
Add support for additional pod annotations and labels

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -28,6 +28,8 @@
 | `service.httpPort` | Port for the HTTP server for readiness and liveness probes. | `8080` |
 | `service.metricsPort` | Port for the metrics. | `8383` |
 | `service.operatorMetricsPort` | Port for the operator metrics. | `8686` |
+| `podAnnotations` | Annotations for vault-secrets-operator pod(s). | `{}` |
+| `podLabels` | Additional labels for the vault-secrets-operator pod(s). | `{}` |
 | `resources` | Set resources for the operator. | `{}` |
 | `volumes` | Provide additional volumns for the container. | `[]` |
 | `nodeSelector` | Set a node selector. | `{}` |

--- a/charts/vault-secrets-operator/templates/_helpers.tpl
+++ b/charts/vault-secrets-operator/templates/_helpers.tpl
@@ -38,10 +38,27 @@ Common labels
 app.kubernetes.io/name: {{ include "vault-secrets-operator.name" . }}
 helm.sh/chart: {{ include "vault-secrets-operator.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels }}
+{{- end }}
+{{- end -}}
+
+{{/*
+matchLabels
+*/}}
+{{- define "vault-secrets-operator.matchLabels" -}}
+app.kubernetes.io/name: {{ include "vault-secrets-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Additional pod annotations
+*/}}
+{{- define "vault-secrets-operator.annotations" -}}
+{{- if .Values.podAnnotations }}
+{{- toYaml .Values.podAnnotations }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "vault-secrets-operator.fullname" . }}
   labels:
 {{ include "vault-secrets-operator.labels" . | indent 4 }}
+  {{- if .Values.podAnnotations }}
+  annotations:
+{{ include "vault-secrets-operator.annotations" . | indent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   {{- with .Values.deploymentStrategy }}
@@ -12,13 +16,15 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "vault-secrets-operator.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+{{ include "vault-secrets-operator.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "vault-secrets-operator.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+{{ include "vault-secrets-operator.labels" . | indent 8 }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+{{ include "vault-secrets-operator.annotations" . | indent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -63,6 +63,12 @@ service:
   metricsPort: 8383
   operatorMetricsPort: 8686
 
+# Annotations for vault-secrets-operator pod(s).
+podAnnotations: {}
+
+# Additional labels for the vault-secrets-operator pod(s).
+podLabels: {}
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
It's now possible to set additional annotations and labels for the vault-secrets-operator pod(s):

```yaml
# Annotations for vault-secrets-operator pod(s).
podAnnotations:
  myannotation: myannotationvalue

# Additional labels for the vault-secrets-operator pod(s).
podLabels:
  mylabel: mylabelvalue
```