### PR TITLE
error level log for metric endpoint creation fail

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -174,7 +174,7 @@ func main() {
 	}
 
 	if err = serveCRMetrics(cfg); err != nil {
-		log.Info("Could not generate and serve custom resource metrics", "error", err.Error())
+		log.Error(err, "Could not generate and serve custom resource metrics")
 	}
 
 	// Add to the below struct any other metrics ports you want to expose.
@@ -185,7 +185,7 @@ func main() {
 	// Create Service object to expose the metrics port(s).
 	service, err := metrics.CreateMetricsService(ctx, cfg, servicePorts)
 	if err != nil {
-		log.Info("Could not create metrics Service", "error", err.Error())
+		log.Error(err, "Could not create metrics Service", err.Error())
 	}
 
 	// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
@@ -193,11 +193,11 @@ func main() {
 	services := []*v1.Service{service}
 	_, err = metrics.CreateServiceMonitors(cfg, namespace, services)
 	if err != nil {
-		log.Info("Could not create ServiceMonitor object", "error", err.Error())
+		log.Error(err, "Could not create ServiceMonitor object")
 		// If this operator is deployed to a cluster without the prometheus-operator running, it will return
 		// ErrServiceMonitorNotPresent, which can be used to safely skip ServiceMonitor creation.
 		if err == metrics.ErrServiceMonitorNotPresent {
-			log.Info("Install prometheus-operator in your cluster to create ServiceMonitor objects", "error", err.Error())
+			log.Error(err, "Install prometheus-operator in your cluster to create ServiceMonitor objects")
 		}
 	}
 


### PR DESCRIPTION
We configured vault-secrets-operator to work in Error log level, to reduce the amount of the logs generated. However, we noticed that if metrics endpoint creation fails, we do not see related logs in Error level.