### PR TITLE
Fix TLS configuration

### DIFF
--- a/charts/vault-secrets-operator/templates/_helpers.tpl
+++ b/charts/vault-secrets-operator/templates/_helpers.tpl
@@ -73,21 +73,6 @@ Create the name of the service account to use.
 {{- end -}}
 
 {{/*
-Inject extra environment variables populated by secrets, if populated.
-*/}}
-{{- define "vault-secrets-operator.environmentVars" -}}
-{{- if .environmentVars -}}
-{{- range .environmentVars }}
-- name: {{ .envName }}
-  valueFrom:
-    secretKeyRef:
-      name: {{ .secretName }}
-      key: {{ .secretKey }}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Inject the necessary rules for the Service Account, if the authentication method is 'kubernetes'.
 */}}
 {{- define "vault-secrets-operator.kubernetesAuthRules" -}}

--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -58,7 +58,9 @@ spec:
               value: {{ .Values.vault.kubernetesRole | quote }}
             - name: VAULT_RECONCILIATION_TIME
               value: {{ .Values.vault.reconciliationTime | quote }}
-            {{- include "vault-secrets-operator.environmentVars" .Values | nindent 12 }}
+            {{- with .Values.environmentVars }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -7,6 +7,8 @@ image:
   pullPolicy: IfNotPresent
   args: []
   volumeMounts: []
+    # - name: ca
+    #   mountPath: "/etc/vault-secrets-operator"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -15,12 +17,15 @@ fullnameOverride: ""
 environmentVars: []
   # Set environment variables from a secret. This must be done, if you use the
   # Token Auth Method of Vault.
-  # - envName: VAULT_TOKEN
-  #   secretName: vault-secrets-operator
-  #   secretKey: VAULT_TOKEN
-  # - envName: VAULT_TOKEN_LEASE_DURATION
-  #   secretName: vault-secrets-operator
-  #   secretKey: VAULT_TOKEN_LEASE_DURATION
+  # - name: VAULT_TOKEN
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: vault-secrets-operator
+  #       key: VAULT_TOKEN
+  # - name: VAULT_TOKEN_LEASE_DURATION
+  #   value: "300"
+  # - name: VAULT_CACERT
+  #   value: "/etc/vault-secrets-operator/ca.pem"
 
 # Set the address for vault (by default we assume you are running a dev
 # instance of vault in the same namespace as the operator) and specify the
@@ -82,6 +87,12 @@ resources: {}
   #   memory: 128Mi
 
 volumes: []
+  # - name: ca
+  #   secret:
+  #     secretName: vault-secrets-operator-ca
+  #     items:
+  #       - key: ca.pem
+  #         path: ca.pem
 
 nodeSelector: {}
 


### PR DESCRIPTION
- Fix the configuration of TLS. The `VAULT_CACERT`, `VAULT_CLIENT_CERT` and `VAULT_CLIENT_KEY` must contain the path the certificate and not the certificate themself. This closes #35.

```yaml
image:
  volumeMounts:
    - name: ca
      mountPath: "/etc/vault-secrets-operator"

environmentVars:
  - name: VAULT_CACERT
    value: "/etc/vault-secrets-operator/ca.pem"

volumes:
  - name: ca
    secret:
      secretName: vault-secrets-operator-ca
      items:
        - key: ca.pem
          path: ca.pem
```

- Change the handling of the `environmentVars` field in the Helm chart.

```diff
environmentVars:
-  - envName: VAULT_TOKEN
-    secretName: vault-secrets-operator
-    secretKey: VAULT_TOKEN
+  - name: VAULT_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: vault-secrets-operator
+        key: VAULT_TOKEN
+  - name: VAULT_TOKEN_LEASE_DURATION
+    value: "300"
```