### PR TITLE
Remove servicemonitor creation from code

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -23,7 +23,7 @@ jobs:
       run: git config --global user.email "mail@ricoberger.de" && git config --global user.name "ricoberger"
 
     - name: Package Helm chart
-      run: helm init --client-only && helm package ./charts/vault-secrets-operator
+      run: helm package ./charts/vault-secrets-operator
 
     - name: Clone Helm repository
       run: git clone https://github.com/ricoberger/helm-charts.git

--- a/charts/README.md
+++ b/charts/README.md
@@ -24,14 +24,15 @@
 | `rbac.create` | Create the cluster role and cluster role bindings. | `true` |
 | `serviceAccount.create` | Create the service account. | `true` |
 | `serviceAccount.name` | The name of the service account, which should be created/used by the operator. | `vault-secrets-operator` |
-| `service.type` | Type of the service, whiche should be created. | `ClusterIP` |
-| `service.httpPort` | Port for the HTTP server for readiness and liveness probes. | `8080` |
-| `service.metricsPort` | Port for the metrics. | `8383` |
-| `service.operatorMetricsPort` | Port for the operator metrics. | `8686` |
 | `podAnnotations` | Annotations for vault-secrets-operator pod(s). | `{}` |
 | `podLabels` | Additional labels for the vault-secrets-operator pod(s). | `{}` |
 | `resources` | Set resources for the operator. | `{}` |
 | `volumes` | Provide additional volumns for the container. | `[]` |
 | `nodeSelector` | Set a node selector. | `{}` |
 | `tolerations` | Set tolerations. | `[]` |
-| `affinity` | Set the affinity. | `{}` |
+| `serviceMonitor.enabled` | Enable the creation of a ServiceMonitor for the Prometheus Operator. | `false` |
+| `serviceMonitor.labels` | Additional labels which should be set for the ServiceMonitor. | `{}` |
+| `serviceMonitor.interval` | Scrape interval. | `10s` |
+| `serviceMonitor.scrapeTimeout` | Scrape timeout. | `10s` |
+| `serviceMonitor.honorLabels` | Honor labels option. | `true` |
+| `serviceMonitor.relabelings` | Additional relabeling config for the ServiceMonitor. | `[]` |

--- a/charts/vault-secrets-operator/templates/NOTES.txt
+++ b/charts/vault-secrets-operator/templates/NOTES.txt
@@ -1,15 +1,9 @@
 1. Get the application URL by running these commands:
-{{- if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "vault-secrets-operator.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "vault-secrets-operator.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "vault-secrets-operator.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.service.operatorMetricsPort }}
-{{- else if contains "ClusterIP" .Values.service.type }}
+
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "vault-secrets-operator.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8686 to use your application"
   kubectl port-forward $POD_NAME 8686
-{{- end }}
+
+{{ if contains "kubernetes" .Values.vault.authMethod }}
+2. Configure Vault using the "{{ template "vault-secrets-operator.serviceAccountName" . }}" ServiceAccount.
+{{ end }}

--- a/charts/vault-secrets-operator/templates/service.yaml
+++ b/charts/vault-secrets-operator/templates/service.yaml
@@ -5,17 +5,13 @@ metadata:
   labels:
 {{ include "vault-secrets-operator.labels" . | indent 4 }}
 spec:
-  type: {{ .Values.service.type }}
+  type: ClusterIP
   ports:
-    - port: {{ .Values.service.httpPort }}
-      targetPort: http
-      protocol: TCP
-      name: http
-    - port: {{ .Values.service.metricsPort }}
+    - port: 8383
       targetPort: metrics
       protocol: TCP
       name: metrics
-    - port: {{ .Values.service.operatorMetricsPort }}
+    - port: 8686
       targetPort: opmetrics
       protocol: TCP
       name: opmetrics

--- a/charts/vault-secrets-operator/templates/servicemonitor.yaml
+++ b/charts/vault-secrets-operator/templates/servicemonitor.yaml
@@ -1,0 +1,39 @@
+{{ if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "vault-secrets-operator.fullname" . }}
+  labels:
+    {{ include "vault-secrets-operator.labels" . | indent 4 }}
+    {{- if .Values.serviceMonitor.labels }}
+      {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      port: 8383
+      path: "/metrics"
+      honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+      {{- if .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml .Values.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
+    - interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      port: 8686
+      path: "/metrics"
+      honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+      {{- if .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml .Values.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
+  jobLabel: "vault-secrets-operator"
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "vault-secrets-operator.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{ end }}

--- a/charts/vault-secrets-operator/templates/servicemonitor.yaml
+++ b/charts/vault-secrets-operator/templates/servicemonitor.yaml
@@ -4,15 +4,15 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "vault-secrets-operator.fullname" . }}
   labels:
-    {{ include "vault-secrets-operator.labels" . | indent 4 }}
-    {{- if .Values.serviceMonitor.labels }}
-      {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
-    {{- end }}
+{{ include "vault-secrets-operator.labels" . | indent 4 }}
+{{- if .Values.serviceMonitor.labels }}
+  {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+{{- end }}
 spec:
   endpoints:
     - interval: {{ .Values.serviceMonitor.interval }}
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
-      port: 8383
+      port: metrics
       path: "/metrics"
       honorLabels: {{ .Values.serviceMonitor.honorLabels }}
       {{- if .Values.serviceMonitor.relabelings }}
@@ -21,7 +21,7 @@ spec:
       {{- end }}
     - interval: {{ .Values.serviceMonitor.interval }}
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
-      port: 8686
+      port: opmetrics
       path: "/metrics"
       honorLabels: {{ .Values.serviceMonitor.honorLabels }}
       {{- if .Values.serviceMonitor.relabelings }}

--- a/charts/vault-secrets-operator/templates/tests/test-connection.yaml
+++ b/charts/vault-secrets-operator/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args:  ['{{ include "vault-secrets-operator.fullname" . }}:{{ .Values.service.operatorMetricsPort }}']
+      args:  ['{{ include "vault-secrets-operator.fullname" . }}:8686']
   restartPolicy: Never

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -62,12 +62,6 @@ serviceAccount:
   create: true
   name: vault-secrets-operator
 
-service:
-  type: ClusterIP
-  httpPort: 8080
-  metricsPort: 8383
-  operatorMetricsPort: 8686
-
 # Annotations for vault-secrets-operator pod(s).
 podAnnotations: {}
 
@@ -99,3 +93,11 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+serviceMonitor:
+  enabled: false
+  labels: {}
+  interval: 10s
+  scrapeTimeout: 10s
+  honorLabels: true
+  relabelings: []

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -22,12 +22,9 @@ import (
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
-	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	"github.com/operator-framework/operator-sdk/pkg/restmapper"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -175,30 +172,6 @@ func main() {
 
 	if err = serveCRMetrics(cfg); err != nil {
 		log.Error(err, "Could not generate and serve custom resource metrics")
-	}
-
-	// Add to the below struct any other metrics ports you want to expose.
-	servicePorts := []v1.ServicePort{
-		{Port: metricsPort, Name: metrics.OperatorPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},
-		{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
-	}
-	// Create Service object to expose the metrics port(s).
-	service, err := metrics.CreateMetricsService(ctx, cfg, servicePorts)
-	if err != nil {
-		log.Error(err, "Could not create metrics Service", err.Error())
-	}
-
-	// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
-	// necessary to configure Prometheus to scrape metrics from this operator.
-	services := []*v1.Service{service}
-	_, err = metrics.CreateServiceMonitors(cfg, namespace, services)
-	if err != nil {
-		log.Error(err, "Could not create ServiceMonitor object")
-		// If this operator is deployed to a cluster without the prometheus-operator running, it will return
-		// ErrServiceMonitorNotPresent, which can be used to safely skip ServiceMonitor creation.
-		if err == metrics.ErrServiceMonitorNotPresent {
-			log.Error(err, "Install prometheus-operator in your cluster to create ServiceMonitor objects")
-		}
 	}
 
 	log.Info("Starting the Cmd.")


### PR DESCRIPTION
- Remove the creation of the `Service` and `ServiceMonitor` from the code of the operator.
- Instead provide an option to create the `ServiceMonitor` via Helm chart.

The following values can be set via the Helm chart:

```yaml
serviceMonitor:
  enabled: false
  labels: {}
  interval: 10s
  scrapeTimeout: 10s
  honorLabels: true
  relabelings: []
```

Closes #37.