### PR TITLE
Add reconcile strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,9 @@ metadata:
 type: Opaque
 ```
 
-the value for `foo` stays as `YmFyCg==` which does not get base64 encoded again.
+The value for `foo` stays as `YmFyCg==` which does not get base64 encoded again.
+
+It is also possible to change the default reconciliation strategy from `Replace` to `Merge` via the `reconcileStrategy` key in the CRD. For the default `Replace` strategy the complete secret is replaced. If you have an existing secret you can choose the `Merge` strategy to add the keys from Vault to the existing secret.
 
 ## Development
 
@@ -312,7 +314,7 @@ export VAULT_RECONCILIATION_TIME=
 Run the operator locally with the default Kubernetes config file present at `$HOME/.kube/config`:
 
 ```sh
-operator-sdk run local --watch-namespace="default"
+operator-sdk run local --watch-namespace=""
 ```
 
 You can use a specific kubeconfig via the flag `--kubeconfig=<path/to/kubeconfig>`.

--- a/charts/vault-secrets-operator/templates/custom-resource-definition.yaml
+++ b/charts/vault-secrets-operator/templates/custom-resource-definition.yaml
@@ -53,6 +53,14 @@ spec:
               path:
                 description: Path is the path of the corresponding secret in Vault.
                 type: string
+              reconcileStrategy:
+                description: ReconcileStrategy defines the strategy for reconcilation.
+                  The default value is "Replace", which replaces any existing data
+                  keys in a secret with the loaded keys from Vault. The second valid
+                  value is "Merge" wiche merges the loaded keys from Vault with the
+                  existing keys in a secret. Duplicated keys will be replaced with
+                  the value from Vault. Other values are not valid for this field.
+                type: string
               secretEngine:
                 description: SecretEngine specifies the type of the Vault secret engine
                   in which the secret is stored. Currently the 'KV Secrets Engine

--- a/deploy/crds/ricoberger.de_vaultsecrets_crd.yaml
+++ b/deploy/crds/ricoberger.de_vaultsecrets_crd.yaml
@@ -50,6 +50,14 @@ spec:
               path:
                 description: Path is the path of the corresponding secret in Vault.
                 type: string
+              reconcileStrategy:
+                description: ReconcileStrategy defines the strategy for reconcilation.
+                  The default value is "Replace", which replaces any existing data
+                  keys in a secret with the loaded keys from Vault. The second valid
+                  value is "Merge" wiche merges the loaded keys from Vault with the
+                  existing keys in a secret. Duplicated keys will be replaced with
+                  the value from Vault. Other values are not valid for this field.
+                type: string
               secretEngine:
                 description: SecretEngine specifies the type of the Vault secret engine
                   in which the secret is stored. Currently the 'KV Secrets Engine

--- a/pkg/apis/ricoberger/v1alpha1/vaultsecret_types.go
+++ b/pkg/apis/ricoberger/v1alpha1/vaultsecret_types.go
@@ -11,6 +11,11 @@ import (
 // VaultSecretSpec defines the desired state of VaultSecret
 // +k8s:openapi-gen=true
 type VaultSecretSpec struct {
+	// ReconcileStrategy defines the strategy for reconcilation. The default value is "Replace", which replaces any
+	// existing data keys in a secret with the loaded keys from Vault. The second valid value is "Merge" wiche merges
+	// the loaded keys from Vault with the existing keys in a secret. Duplicated keys will be replaced with the value
+	// from Vault. Other values are not valid for this field.
+	ReconcileStrategy string `json:"reconcileStrategy,omitempty"`
 	// Keys is an array of Keys, which should be included in the Kubernetes
 	// secret. If the Keys field is ommitted all keys from the Vault secret will
 	// be included in the Kubernetes secret.


### PR DESCRIPTION
Add a new key `reconcileStrategy` to the CRD to define the strategy for reconciliation. The default strategy is `Replace`, which corresponds to the current behavior, where an existing is completed replaced with the data from Vault.

The second strategy is `Merge`, where the keys from Vault are merged with any existing keys, see the detailed explanation from @sarahhenkens at #39.

Example:

- You have an existing secret `merge` with a key `foo`
- You create a vault secret with the same name and the key `hello`
- The resulting secret contains both keys `foo` and `hello` with the `Merge` strategy

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: merge
data:
  foo: YmFyCg==
type: Opaque
```

```yaml
apiVersion: ricoberger.de/v1alpha1
kind: VaultSecret
metadata:
  name: merge
spec:
  reconcileStrategy: Merge
  keys:
    - hello
  path: kubernetes/merge
  type: Opaque
```

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: merge
data:
  foo: YmFyCg==
  hello: d29ybGQ=
type: Opaque
```

Closes #39.