### PR TITLE
Update Readme.md change bad environmentVar example

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,16 @@ This creates a secret named `vault-secrets-operator`. To use this secret in the 
 
 ```yaml
 environmentVars:
-  - envName: VAULT_TOKEN
-    secretName: vault-secrets-operator
-    secretKey: VAULT_TOKEN
-  - envName: VAULT_TOKEN_LEASE_DURATION
-    secretName: vault-secrets-operator
-    secretKey: VAULT_TOKEN_LEASE_DURATION
+	- name: VAULT_TOKEN
+	valueFrom:
+	  secretKeyRef:
+		name: vault-secrets-operator
+		key: VAULT_TOKEN
+	- name: VAULT_TOKEN_LEASE_DURATION
+	valueFrom:
+	  secretKeyRef:
+		name: vault-secrets-operator
+		key: VAULT_TOKEN_LEASE_DURATION
 ```
 
 #### Kubernetes Auth Method

--- a/README.md
+++ b/README.md
@@ -75,16 +75,16 @@ This creates a secret named `vault-secrets-operator`. To use this secret in the 
 
 ```yaml
 environmentVars:
-	- name: VAULT_TOKEN
-	valueFrom:
-	  secretKeyRef:
-		name: vault-secrets-operator
-		key: VAULT_TOKEN
-	- name: VAULT_TOKEN_LEASE_DURATION
-	valueFrom:
-	  secretKeyRef:
-		name: vault-secrets-operator
-		key: VAULT_TOKEN_LEASE_DURATION
+  - name: VAULT_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: vault-secrets-operator
+        key: VAULT_TOKEN
+  - name: VAULT_TOKEN_LEASE_DURATION
+    valueFrom:
+      secretKeyRef:
+        name: vault-secrets-operator
+        key: VAULT_TOKEN_LEASE_DURATION
 ```
 
 #### Kubernetes Auth Method


### PR DESCRIPTION
As stated here : https://v1-14.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#envvarsource-v1-core
environmentVars should be set with valueFrom and secretKeyRef, the old one is not working anymore