### PR TITLE
adding support for remote Kustomize base

### DIFF
--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- crds/ricoberger.de_v1alpha1_vaultsecret_cr.yaml
+- crds/ricoberger.de_vaultsecrets_crd.yaml
+- operator.yaml
+- role.yaml
+- role_binding.yaml
+- service_account.yaml

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deploy/


### PR DESCRIPTION
Allows for Kustomize install as a remote base or by running `kubectl kustomize github.com/ricoberger/vault-secrets-operator`