### PR TITLE
Remove the vault-secret CRD from kustomization

### DIFF
--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- crds/ricoberger.de_v1alpha1_vaultsecret_cr.yaml
 - crds/ricoberger.de_vaultsecrets_crd.yaml
 - operator.yaml
 - role.yaml


### PR DESCRIPTION
I misunderstood your comment the other day as I was just waking up, you are correct this should not be present in the kustomization for the install.