### PR TITLE
Parameterise token renewal intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To use Token auth method for the authentication against the Vault API, you need 
 vault token create -period=24h -policy=vault-secrets-operator
 ```
 
-To use the created token you need to pass the token as environment variable to the operator. For security reaseons the operator only supports the passing of environment variables via a Kubernetes secret. The secret with the keys `VAULT_TOKEN` and `VAULT_TOKEN_LEASE_DURATION` can be created with the following command:
+To use the created token you need to pass the token as an environment variable to the operator. For security reasons the operator only supports the passing of environment variables via a Kubernetes secret. The secret with the keys `VAULT_TOKEN` and `VAULT_TOKEN_LEASE_DURATION` (as well as optional keys `VAULT_TOKEN_RENEWAL_INTERVAL` and `VAULT_TOKEN_RENEWAL_RETRY_INTERVAL` to control timings for token renewals, if required) can be created with the following command:
 
 ```sh
 export VAULT_TOKEN=

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -26,6 +26,10 @@ environmentVars: []
   #   value: "300"
   # - name: VAULT_CACERT
   #   value: "/etc/vault-secrets-operator/ca.pem"
+  # - name: VAULT_TOKEN_RENEWAL_INTERVAL
+  #   value: "43200"
+  # - name: VAULT_TOKEN_RENEWAL_RETRY_INTERVAL
+  #   value: "30"
 
 # Set the address for vault (by default we assume you are running a dev
 # instance of vault in the same namespace as the operator) and specify the


### PR DESCRIPTION
For particular Vault setups, the default values for token renewals might
not be a good fit. This commit adds a parametrisation, so that the time
between a successful or failed token renewal and the next renewal attempt
can be controlled via optional environment variables.

`VAULT_TOKEN_RENEWAL_INTERVAL`:
* The time (in seconds) between a successful token renewal and the
    next renewal attempt. **Default: 50% of the token lease duration**

`VAULT_TOKEN_RENEWAL_RETRY_INTERVAL`:
* The time (in seconds) between a failed token renewal and the next
    renewal attempt. **Default: 30 seconds**

Refs #48