### PR TITLE
Allow namespaced deploys

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -21,7 +21,9 @@
 | `vault.reconciliationTime` | The time after which the reconcile function for the CR is rerun. If the value is 0, automatic reconciliation is skipped. | `0` |
 | `vault.namespaces` | Comma serpareted list of namespaces the operator will watch. If empty the operator will watch all namespaces. | `""` |
 | `crd.create` | Create the custom resource definition. | `true` |
-| `rbac.create` | Create the cluster role and cluster role bindings. | `true` |
+| `rbac.create` | Create RBAC object, enable ClusterRole and (Cluster)Role binding creation. | `true` |
+| `rbac.createclusterrole` | Finetune RBAC, enable or disable ClusterRole creation. NOTE: ignored when `rbac.create` not `true`. | `true` |
+| `rbac.namespaced` | Deploy in isolated namespace. Creates RoleBinding instead of a ClusterRoleBinding | `false` |
 | `serviceAccount.create` | Create the service account. | `true` |
 | `serviceAccount.name` | The name of the service account, which should be created/used by the operator. | `vault-secrets-operator` |
 | `podAnnotations` | Annotations for vault-secrets-operator pod(s). | `{}` |

--- a/charts/vault-secrets-operator/templates/cluster-role.yaml
+++ b/charts/vault-secrets-operator/templates/cluster-role.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.rbac.create }}
+{{ if and .Values.rbac.create .Values.rbac.createclusterrole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -39,7 +39,11 @@ spec:
             {{- toYaml .Values.image.args | nindent 12 }}
           env:
             - name: WATCH_NAMESPACE
+            {{- if .Values.rbac.namespaced }}
+              value: {{ .Release.Namespace | quote }}
+            {{- else }}
               value: {{ .Values.vault.namespaces | quote }}
+            {{- end }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/charts/vault-secrets-operator/templates/role-binding.yaml
+++ b/charts/vault-secrets-operator/templates/role-binding.yaml
@@ -1,6 +1,6 @@
 {{ if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: {{ if not .Values.rbac.namespaced -}} Cluster {{- end -}} RoleBinding
 metadata:
   name: {{ template "vault-secrets-operator.fullname" . }}
   labels:

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -46,7 +46,8 @@ environmentVars: []
 # Vault secret changes. A value of 0 will disable the automatic update.
 # You can specify all namespaces the operator should watch. Therefor pass a
 # comma separated list via the namespaces value. If the value is empty the operator
-# will watch all namespaces.
+# will watch all namespaces. Namespaces are ignored if rbac.namespaced is set to
+# true, then the namespace of the release will be used
 vault:
   address: "http://vault:8200"
   authMethod: token
@@ -61,6 +62,8 @@ crd:
 
 rbac:
   create: true
+  createclusterrole: true
+  namespaced: false
 
 serviceAccount:
   create: true


### PR DESCRIPTION
This change in the helm chart enables you to install the helm operator in multiple namespaces, with only permission on that namespace.

Without this change, all deploys on the entire cluster have access to the same secrets everywhere, which is not ideal if you want to have separate vault policies per namespace.

I modified the behaviour of the helm chart, adding a few new rbac options:

* `rbac.createclusterrole` toggles the creation of the (global) cluster role. This is only necessary once, and only enable this on an internal "management" namespace, where all helm deploys are owner of all CRD's and cluster roles. Note that this will only create the cluster role if `rbac.create` is also set.
*  `rbac.namespaced`: this does a few things:
    * a `RoleBinding` is created instead of a `ClusterRoleBinding`
    * The `WATCH_NAMESPACE` env var is overridden to be the `.Release.Namespace`, so only this namespace (where the operator has permissions) is watched.

