### PR TITLE
Add templated secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,96 @@ The value for `foo` stays as `YmFyCg==` which does not get base64 encoded again.
 
 It is also possible to change the default reconciliation strategy from `Replace` to `Merge` via the `reconcileStrategy` key in the CRD. For the default `Replace` strategy the complete secret is replaced. If you have an existing secret you can choose the `Merge` strategy to add the keys from Vault to the existing secret.
 
+### Using templated secrets
+
+When straight-forward secrets are not sufficient, and the target secrets need to be formatted in a certain way, you can use basic templating to format the secrets. There are multiple uses for this:
+
+* Generate URIs which contain secrets
+* Format secrets in a specific way, for example when using the [Helm Operator](https://docs.fluxcd.io/projects/helm-operator/) which [can use secrets as a source](https://docs.fluxcd.io/projects/helm-operator/en/stable/helmrelease-guide/values/#secrets) for its Helm chart parameterisation, but they have to be in YAML format wrapped inside a secret, like [`secretGenerator`](https://kubernetes-sigs.github.io/kustomize/api-reference/kustomization/secretegenerator/) from [Kustomize](https://kustomize.io) also generates.
+
+To do this, specify keys under `spec.templates`, containing a valid template string. 
+When `templates` is defined, the standard generation of secrets is disabled, and only the defined templates will be generated.
+
+The templating uses the standard Go templating engine, also used in tools such as [Helm](https://helm.sh) or [Gomplate](https://gomplate.ca). The main differentiator here is that the `{%` and `%}` delimiters are used to prevent conflicts with standard Go templating tools such as Helm, which use `{{` and `}}` for this.
+
+The available functions during templating are the set offered by the [Sprig library](http://masterminds.github.io/sprig/) (similar to [Helm](https://helm.sh/docs/chart_template_guide/function_list/), but different from [Gomplate](https://docs.gomplate.ca)), excluding the following functions for security-reasons or their non-idempotent nature to avoid reconciliation problems:
+
+* `genPrivateKey`
+* `genCA`
+* `genSelfSignedCert`
+* `genSignedCert`
+* `htpasswd`
+* `getHostByName`
+* Random functions
+* Date/time functionality
+* Environment variable functions (for security reasons)
+
+An example of a URI formatting secret:
+
+```yaml
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: kvv1-example-vaultsecret
+spec:
+  keys:
+    - foo
+    - bar
+  isBinary: true
+  path: kvv1/example-vaultsecret
+  templates:
+    fooUri: "https://user:{% .Vault.foo %}@some-site/api"
+    barUri: "redis://{% .Vault.bar %}@redis/0"
+  type: Opaque
+```
+
+The resulting secret will look like:
+
+```yaml
+apiVersion: v1
+data:
+  fooUri: aHR0cHM6Ly91c2VyOmZvb0Bzb21lLXNpdGUvYXBpCg==
+  barUri: cmVkaXM6Ly9iYXJAcmVkaXMvMAo=
+kind: Secret
+metadata:
+  labels:
+    created-by: vault-secrets-operator
+  name: kvv1-example-vaultsecret
+type: Opaque
+```
+
+This is a more advanced example for a secret that can be used by [HelmOperator](https://docs.fluxcd.io/projects/helm-operator/) as [`valuesFrom[].secretKeyRef`](https://docs.fluxcd.io/projects/helm-operator/en/stable/helmrelease-guide/values/#secrets):
+
+```yaml
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: kvv1-example-vaultsecret
+spec:
+  keys:
+    - foo
+    - bar
+    - baz
+  isBinary: true
+  path: kvv1/example-vaultsecret
+  templates:
+    values.yaml: |-
+      secrets:
+      {%- range $k, $v := .Vault %}
+        {% $k %}: {% $v | quote -%}
+      {% end %}
+  type: Opaque
+```
+
+This will loop over all secrets fetched from Vault, and set the `vault.yaml` key to a string like this:
+
+```yaml
+secrets:
+  foo: "foovalue"
+  bar: "barvalue"
+  baz: "bazvalue
+```
+
 ## Development
 
 After modifying the `*_types.go` file always run the following command to update the generated code for that resource type:

--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ The context available in the templating engine contains the following items:
   * `.Vault.Address`: configured address of the Vault instance
   * `.Vault.Path`: path of the Vault secret that was fetched
 * `.Namespace`: Namespace where the custom resource instance was deployed.
+* `.Labels`: access to the labels of the custom resource instance
+* `.Annotations`: access to the annotations of the custom resource instance
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -326,6 +326,8 @@ apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:
   name: kvv1-example-vaultsecret
+  annotations:
+    redisdb: "0"
 spec:
   keys:
     - foo
@@ -333,7 +335,7 @@ spec:
   path: kvv1/example-vaultsecret
   templates:
     fooUri: "https://user:{% .Secrets.foo %}@{% .Namespace %}.somesite.tld/api"
-    barUri: "redis://{% .Secrets.bar %}@redis/0"
+    barUri: "redis://{% .Secrets.bar %}@redis/{% .Annotations.redisdb %}"
   type: Opaque
 ```
 

--- a/README.md
+++ b/README.md
@@ -318,8 +318,8 @@ spec:
     - bar
   path: kvv1/example-vaultsecret
   templates:
-    fooUri: "https://user:{% .Vault.foo %}@some-site/api"
-    barUri: "redis://{% .Vault.bar %}@redis/0"
+    fooUri: "https://user:{% .Secrets.foo %}@some-site/api"
+    barUri: "redis://{% .Secrets.bar %}@redis/0"
   type: Opaque
 ```
 
@@ -354,7 +354,7 @@ spec:
   templates:
     values.yaml: |-
       secrets:
-      {%- range $k, $v := .Vault %}
+      {%- range $k, $v := .Secrets %}
         {% $k %}: {% $v | quote -%}
       {% end %}
   type: Opaque

--- a/README.md
+++ b/README.md
@@ -316,7 +316,6 @@ spec:
   keys:
     - foo
     - bar
-  isBinary: true
   path: kvv1/example-vaultsecret
   templates:
     fooUri: "https://user:{% .Vault.foo %}@some-site/api"
@@ -351,7 +350,6 @@ spec:
     - foo
     - bar
     - baz
-  isBinary: true
   path: kvv1/example-vaultsecret
   templates:
     values.yaml: |-
@@ -370,6 +368,10 @@ secrets:
   bar: "barvalue"
   baz: "bazvalue
 ```
+
+#### Notes
+
+* All secrets data is converted to string before being passed to the templating engine, so using binary data will not work well, or at least be unpredictable.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ secrets:
   baz: "bazvalue
 ```
 
-#### Notes
+#### Notes on templating
 
 * All secrets data is converted to string before being passed to the templating engine, so using binary data will not work well, or at least be unpredictable.
 

--- a/README.md
+++ b/README.md
@@ -305,6 +305,18 @@ The available functions during templating are the set offered by the [Sprig libr
 * Date/time functionality
 * Environment variable functions (for security reasons)
 
+#### Templating context
+
+The context available in the templating engine contains the following items:
+
+* `.Secrets`: Map with all the secrets fetched from vault. Key = secret name, Value = secret value
+* `.Vault`: Contains misc info about the Vault setup
+  * `.Vault.Address`: configured address of the Vault instance
+  * `.Vault.Path`: path of the Vault secret that was fetched
+* `.Namespace`: Namespace where the custom resource instance was deployed.
+
+#### Examples
+
 An example of a URI formatting secret:
 
 ```yaml
@@ -318,7 +330,7 @@ spec:
     - bar
   path: kvv1/example-vaultsecret
   templates:
-    fooUri: "https://user:{% .Secrets.foo %}@some-site/api"
+    fooUri: "https://user:{% .Secrets.foo %}@{% .Namespace %}.somesite.tld/api"
     barUri: "redis://{% .Secrets.bar %}@redis/0"
   type: Opaque
 ```
@@ -328,7 +340,7 @@ The resulting secret will look like:
 ```yaml
 apiVersion: v1
 data:
-  fooUri: aHR0cHM6Ly91c2VyOmZvb0Bzb21lLXNpdGUvYXBpCg==
+  fooUri: aHR0cHM6Ly91c2VyOmZvb0BuYW1lc3BhY2UuLnNvbWVzaXRlLnRsZC9hcGkK
   barUri: cmVkaXM6Ly9iYXJAcmVkaXMvMAo=
 kind: Secret
 metadata:

--- a/charts/vault-secrets-operator/templates/custom-resource-definition.yaml
+++ b/charts/vault-secrets-operator/templates/custom-resource-definition.yaml
@@ -73,7 +73,7 @@ spec:
                 additionalProperties:
                   type: string
                 description: Templates, if not empty will be run through the the Go
-                  templating engine, with `.Vault` being mapped to the list of secrets
+                  templating engine, with `.Secrets` being mapped to the list of secrets
                   received from Vault. When omitted set, all secrets will be added
                   as key/val pairs under Secret.data.
                 type: object

--- a/charts/vault-secrets-operator/templates/custom-resource-definition.yaml
+++ b/charts/vault-secrets-operator/templates/custom-resource-definition.yaml
@@ -1,10 +1,10 @@
-{{ if .Values.crd.create }}
+{{- if .Values.crd.create }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: vaultsecrets.ricoberger.de
   labels:
-{{ include "vault-secrets-operator.labels" . | indent 4 }}
+    {{- include "vault-secrets-operator.labels" . | nindent 4 }}
 spec:
   group: ricoberger.de
   names:
@@ -69,6 +69,14 @@ spec:
                   is used the Vault Secrets Operator will try to use the KV secret
                   engine.
                 type: string
+              templates:
+                additionalProperties:
+                  type: string
+                description: Templates, if not empty will be run through the the Go
+                  templating engine, with `.Vault` being mapped to the list of secrets
+                  received from Vault. When omitted set, all secrets will be added
+                  as key/val pairs under Secret.data.
+                type: object
               type:
                 description: Type is the type of the Kubernetes secret, which will
                   be created by the Vault Secrets Operator.
@@ -93,4 +101,4 @@ spec:
     storage: true
     subresources:
       status: {}
-{{ end }}
+{{ end -}}

--- a/deploy/crds/ricoberger.de_vaultsecrets_crd.yaml
+++ b/deploy/crds/ricoberger.de_vaultsecrets_crd.yaml
@@ -66,6 +66,14 @@ spec:
                   is used the Vault Secrets Operator will try to use the KV secret
                   engine.
                 type: string
+              templates:
+                additionalProperties:
+                  type: string
+                description: Templates, if not empty will be run through the the Go
+                  templating engine, with `.Vault` being mapped to the list of secrets
+                  received from Vault. When omitted set, all secrets will be added
+                  as key/val pairs under Secret.data.
+                type: object
               type:
                 description: Type is the type of the Kubernetes secret, which will
                   be created by the Vault Secrets Operator.

--- a/deploy/crds/ricoberger.de_vaultsecrets_crd.yaml
+++ b/deploy/crds/ricoberger.de_vaultsecrets_crd.yaml
@@ -70,7 +70,7 @@ spec:
                 additionalProperties:
                   type: string
                 description: Templates, if not empty will be run through the the Go
-                  templating engine, with `.Vault` being mapped to the list of secrets
+                  templating engine, with `.Secrets` being mapped to the list of secrets
                   received from Vault. When omitted set, all secrets will be added
                   as key/val pairs under Secret.data.
                 type: object

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/ricoberger/vault-secrets-operator
 go 1.13
 
 require (
+	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/hashicorp/vault/api v1.0.4
 	github.com/operator-framework/operator-sdk v0.18.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,15 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
+github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvoqmMUQk=
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
+github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=
+github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
+github.com/Masterminds/sprig/v3 v3.1.0 h1:j7GpgZ7PdFqNsmncycTHsLmVPf5/3wJtlgW9TNDYD9Y=
 github.com/Masterminds/sprig/v3 v3.1.0/go.mod h1:ONGMf7UfYGAbMXCZmQLy8x3lCDIPrEZE/rU8pmrbihA=
 github.com/Masterminds/squirrel v1.2.0/go.mod h1:yaPeOnPG5ZRwL9oKdTsO/prlkPbXWZlRVMQ/gGlzIuA=
 github.com/Masterminds/vcs v1.13.1/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=
@@ -509,6 +516,7 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKe
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/huandu/xstrings v1.3.1 h1:4jgBlKK6tLKFvO8u5pmYjG91cqytmDCDvGh7ECVFfFs=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -613,6 +621,7 @@ github.com/mikefarah/yq/v2 v2.4.1/go.mod h1:i8SYf1XdgUvY2OFwSqGAtWOOgimD2McJ6iut
 github.com/minio/minio-go/v6 v6.0.49/go.mod h1:qD0lajrGW49lKZLtXKtCB4X/qkMf0a5tBvN2PaZg7Gg=
 github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
+github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
@@ -627,6 +636,7 @@ github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:F
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
+github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
@@ -833,6 +843,7 @@ github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=

--- a/pkg/apis/ricoberger/v1alpha1/vaultsecret_types.go
+++ b/pkg/apis/ricoberger/v1alpha1/vaultsecret_types.go
@@ -20,6 +20,10 @@ type VaultSecretSpec struct {
 	// secret. If the Keys field is ommitted all keys from the Vault secret will
 	// be included in the Kubernetes secret.
 	Keys []string `json:"keys,omitempty"`
+	// Templates, if not empty will be run through the the Go templating engine, with `.Vault` being mapped
+	// to the list of secrets received from Vault. When omitted set, all secrets will be added as key/val pairs
+	// under Secret.data.
+	Templates map[string]string `json:"templates,omitempty"`
 	// Path is the path of the corresponding secret in Vault.
 	Path string `json:"path"`
 	// SecretEngine specifies the type of the Vault secret engine in which the

--- a/pkg/apis/ricoberger/v1alpha1/vaultsecret_types.go
+++ b/pkg/apis/ricoberger/v1alpha1/vaultsecret_types.go
@@ -20,7 +20,7 @@ type VaultSecretSpec struct {
 	// secret. If the Keys field is ommitted all keys from the Vault secret will
 	// be included in the Kubernetes secret.
 	Keys []string `json:"keys,omitempty"`
-	// Templates, if not empty will be run through the the Go templating engine, with `.Vault` being mapped
+	// Templates, if not empty will be run through the the Go templating engine, with `.Secrets` being mapped
 	// to the list of secrets received from Vault. When omitted set, all secrets will be added as key/val pairs
 	// under Secret.data.
 	Templates map[string]string `json:"templates,omitempty"`

--- a/pkg/apis/ricoberger/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/ricoberger/v1alpha1/zz_generated.deepcopy.go
@@ -77,6 +77,13 @@ func (in *VaultSecretSpec) DeepCopyInto(out *VaultSecretSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Templates != nil {
+		in, out := &in.Templates, &out.Templates
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/controller/vaultsecret/vaultsecret_controller.go
+++ b/pkg/controller/vaultsecret/vaultsecret_controller.go
@@ -174,11 +174,11 @@ type templateVaultContext struct {
 	Address string
 }
 type templateContext struct {
-	Secrets   map[string]string
-	Vault     templateVaultContext
-	Namespace string
-	// Labels      map[string]string
-	// Annotations map[string]string
+	Secrets     map[string]string
+	Vault       templateVaultContext
+	Namespace   string
+	Labels      map[string]string
+	Annotations map[string]string
 }
 
 // runTemplate executes a template with the given secrets map, filled with the Vault secres
@@ -190,9 +190,9 @@ func runTemplate(cr *ricobergerv1alpha1.VaultSecret, tmpl string, secrets map[st
 			Path:    cr.Spec.Path,
 			Address: os.Getenv("VAULT_ADDRESS"),
 		},
-		Namespace: cr.Namespace,
-		// Labels:      cr.Labels,
-		// Annotations: cr.Annotations,
+		Namespace:   cr.Namespace,
+		Labels:      cr.Labels,
+		Annotations: cr.Annotations,
 	}
 	// For templating, these should all be strings, convert
 	for k, v := range secrets {


### PR DESCRIPTION
This PR allows adds the possibility of templating of the values the generated secrets, based on the values coming from Vault. Before considering merging, I think some things should be discussed.

## Reasoning

There are 2 main reasons for this addition:

* Secrets which contain passwords that need to be injected in URI's for the application. You don't necessarily want to store the entire URI in a Vault secret. I know this is not ideal, and should be avoided, but it's something I have had to deal with, where this was not under my control.
* Allow you to create secrets the [Helm Operator can use as a source for configuring a HelmRelease](https://docs.fluxcd.io/projects/helm-operator/en/stable/helmrelease-guide/values/#secrets). The issue is that it expects a YAML-formatted string inside the secret (by default using the `values.yaml` key).

## Small overview of the changes/new behaviour

* When `spec.templates` is not defined or empty in a `VaultSecret` object, , the current behaviour remains.
* When `spec.templates` is defined, no other secrets are generated.
* `spec.templates` should contain keys containing a template string, which will be generated as `key: <templated result>` in the final secret.
* This uses the standard Go templating language, but:
  * adds the [Sprig](https://github.com/Masterminds/sprig) library (also used by Helm) to add extra functions in the templates, but with some removed for security and idempotency reasons (which would cause a reconciliation storm).
  * uses the `{%` and `%}` delimiters to avoid conflicts with other templating tools regularly used in a k8s environment (read: Helm)

## Remarks/considerations/discussion points

* I had to update the `pkg/apis/ricoberger/v1alpha1/vaultsecret_types.go` file, so the CRD has been updated. I kept everything backwards compatible, but I don't think that's good enough. Upgrading CRD's seems to be a major pain-point at the moment, I'm not sure how this should be handled, and if a version bump would be required.
* All secrets are converted from `[]byte` to `string` before templating, this can potentially cause issues with strictly binary secrets. Maybe this should be handled better? Otherwise it should probably be added to the documentation.
* I ran in some issues with the older operator-sdk that's required (I used `v0.18.2`), where I had to specify a dummy `GOROOT` environment, or the `operator-sdk generate k8s` command failed (found an issue about this somewhere, can't find it immediately)

## Examples how to use this

### Simple example

```yaml
apiVersion: ricoberger.de/v1alpha1
kind: VaultSecret
metadata:
  name: kvv1-example-vaultsecret
spec:
  keys:
    - foo
    - bar
  isBinary: true
  path: kvv1/example-vaultsecret
  templates:
    fooUri: "https://user:{% .Vault.foo %}@some-site/api"
    barUri: "redis://{% .Vault.bar %}@redis/0"
  type: Opaque
```

### Generate a `HelmRelease` compatible secret

```yaml
apiVersion: ricoberger.de/v1alpha1
kind: VaultSecret
metadata:
  name: kvv1-example-vaultsecret
spec:
  keys:
    - foo
    - bar
    - baz
  isBinary: true
  path: kvv1/example-vaultsecret
  templates:
    values.yaml: |-
      secrets:
      {%- range $k, $v := .Vault %}
        {% $k %}: {% $v | quote -%}
      {% end %}
  type: Opaque
```
