### PR TITLE
Added finalizers for OpenShift in RBAC

### DIFF
--- a/charts/vault-secrets-operator/templates/cluster-role.yaml
+++ b/charts/vault-secrets-operator/templates/cluster-role.yaml
@@ -23,6 +23,9 @@ rules:
     - ricoberger.de
     resources:
     - vaultsecrets
+{{- if .Capabilities.APIVersions.Has "route.openshift.io/v1/Route" }}
+    - vaultsecrets/finalizers
+{{- end }}
     verbs:
     - create
     - delete


### PR DESCRIPTION
Fixes an OpenShift RBAC compatibility issue in helm chart. Found the solution here: https://github.com/spotahome/redis-operator/issues/98

If you don't specifically mention the `vaultsecrets/finalizers` resource next to the `vaultsecrets` in the ClusterRole, you get an error like this in the reconciliation loop:

```
2020-12-28T15:06:04.328Z	INFO	controllers.VaultSecret	Creating a new Secret	{"vaultsecret": "testnamespace/test-vault-secret", "Secret.Namespace": "testnamespace", "Secret.Name": "test-vault-secret"}
2020-12-28T15:06:04.334Z	ERROR	controller	Reconciler error	{"reconcilerGroup": "ricoberger.de", "reconcilerKind": "VaultSecret", "controller": "vaultsecret", "name": "test-vault-secret", "namespace": "testnamespace", "error": "secrets \"test-vault-secret\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"}
github.com/go-logr/zapr.(*zapLogger).Error
```

I currently wrapped the additional resource in a condition which checks for an OpenShift specific API to be present on the target cluster. Not sure if this is the way to go, and if this condition is even necessary. I have only tested this with Helm 3 on OpenShift 4, and briefly on a local [kind](https://kind.sigs.k8s.io) instance.