### PR TITLE
Helm Chart: Added Ability To Specify 'priorityClassName' For Pods

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -37,3 +37,4 @@
 | `serviceMonitor.scrapeTimeout` | Scrape timeout. | `10s` |
 | `serviceMonitor.honorLabels` | Honor labels option. | `true` |
 | `serviceMonitor.relabelings` | Additional relabeling config for the ServiceMonitor. | `[]` |
+| `priorityClassName` | Optionally attach priority class to pod spec. | `null` |

--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -98,3 +98,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -107,3 +107,6 @@ serviceMonitor:
   scrapeTimeout: 10s
   honorLabels: true
   relabelings: []
+
+# A priority class can be optionally attached to the pod spec if one is needed
+# priorityClassName: high


### PR DESCRIPTION
### About

This PR adds the ability to specify the `priorityClassName` for the pod in the deployment. If it is not specified (or is `null`), then it is simply not used.

The reason that I wanted to implement this is because I found myself needing it. My applications depend on vault secrets to be present and will not function properly if they are not there. For that reason, I would rather have my application pods be evicted before the pods that are in charge of syncing secrets from vault.

### Backwards Compatibility

This should be backwards compatible since specifying no value for `priorityClassName` results in the current implementation's behavior.