### PR TITLE
Improve kustomize files

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,6 +1,8 @@
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - bases/ricoberger.de_vaultsecrets.yaml
 # +kubebuilder:scaffold:crdkustomizeresource

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,7 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # Adds namespace to all resources.
 namespace: vault-secrets-operator
-
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - namespace.yaml
 - deploy.yaml

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - role.yaml
 - role_binding.yaml

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,4 +1,6 @@
 ## Append samples you want in your CSV to this file as resources ##
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - ricoberger.de_v1alpha1_vaultsecret.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/testbin/setup-kind.sh
+++ b/testbin/setup-kind.sh
@@ -48,7 +48,7 @@ kubectl create ns vault-secrets-operator
 
 # Install Vault in the cluster and create a new secret engine for the operator
 helm repo add hashicorp https://helm.releases.hashicorp.com
-helm upgrade --install vault hashicorp/vault --namespace=vault --set server.dev.enabled=true --set injector.enabled=false
+helm upgrade --install vault hashicorp/vault --namespace=vault --version=0.8.0 --set server.dev.enabled=true --set injector.enabled=false
 
 sleep 10s
 kubectl wait pod/vault-0 --namespace=vault  --for=condition=Ready --timeout=180s


### PR DESCRIPTION
- Use `resources` instead of `bases`, because the `bases` field was deprecated in v2.1.0 (https://kubectl.docs.kubernetes.io/references/kustomize/bases/)
- Add `apiVersion` and `kind` for the kustomize files.

Closes #71.