### PR TITLE
Remove whitespaces in watchNamespace

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func main() {
 	// Add support for MultiNamespace set in WATCH_NAMESPACE (e.g ns1,ns2)
 	if strings.Contains(watchNamespace, ",") {
 		setupLog.Info("manager set up with multiple namespaces", "namespaces", watchNamespace)
-		// remove extra whitespaces (e.g. WATCH_NAMESPACE=ns1, ns2)
+		// remove whitespaces (e.g. WATCH_NAMESPACE=ns1, ns2)
 		watchNamespace = strings.ReplaceAll(watchNamespace, " ", "")
 		// configure cluster-scoped with MultiNamespacedCacheBuilder
 		options.Namespace = ""

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 
 	ricobergerdev1alpha1 "github.com/ricoberger/vault-secrets-operator/api/v1alpha1"
@@ -81,7 +82,8 @@ func main() {
 	if strings.Contains(watchNamespace, ",") {
 		setupLog.Info("manager set up with multiple namespaces", "namespaces", watchNamespace)
 		// remove whitespaces (e.g. WATCH_NAMESPACE=ns1, ns2)
-		watchNamespace = strings.ReplaceAll(watchNamespace, " ", "")
+		space := regexp.MustCompile(`\s+`)
+		watchNamespace = space.ReplaceAllString(watchNamespace, "")
 		// configure cluster-scoped with MultiNamespacedCacheBuilder
 		options.Namespace = ""
 		options.NewCache = cache.MultiNamespacedCacheBuilder(strings.Split(watchNamespace, ","))

--- a/main.go
+++ b/main.go
@@ -80,6 +80,8 @@ func main() {
 	// Add support for MultiNamespace set in WATCH_NAMESPACE (e.g ns1,ns2)
 	if strings.Contains(watchNamespace, ",") {
 		setupLog.Info("manager set up with multiple namespaces", "namespaces", watchNamespace)
+		// remove extra whitespaces (e.g. WATCH_NAMESPACE=ns1, ns2)
+		watchNamespace = strings.ReplaceAll(watchNamespace, " ", "")
 		// configure cluster-scoped with MultiNamespacedCacheBuilder
 		options.Namespace = ""
 		options.NewCache = cache.MultiNamespacedCacheBuilder(strings.Split(watchNamespace, ","))


### PR DESCRIPTION
Remove whitespaces in watchNamespace when multiple namespaces are specified.

Right now, if you pass a list of namespaces with a whitespace after comma, like this: `ns1, ns2, ns3` (more readable than `ns1,ns2,ns3`), vault operator will split this string into ["ns1", " ns2", " ns3"] and it will fail to watch namespaces " ns2" and " ns3".

Update:
Remove all whitespaces.
The tools used over helm (himl, helmfile, spinnaker etc) can potentially insert different whitespaces between namespaces.


