### PR TITLE
Add support for AppRole auth method for Vault

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        test: [kubernetes-sharedclient, kubernetes-nosharedclient, kubernetes-namespaced]
+        test:
+          - kubernetes-sharedclient
+          - kubernetes-nosharedclient
+          - kubernetes-namespaced
+          - approle
     defaults:
       run:
         shell: bash

--- a/README.md
+++ b/README.md
@@ -135,6 +135,41 @@ vault:
   authMethod: kubernetes
 ```
 
+#### AppRole Auth Method
+
+To use AppRole auth method for the authentication against the Vault API, you need to create a new AppRole.
+
+
+```sh
+# Enable AppRole auth method:
+vault auth enable approle
+
+# AppRole with the previously created policy can be created as follows:
+vault write auth/approle/role/vault-secrets-operator \
+  token_policies=vault-secrets-operator
+
+# Get AppRole ID:
+vault read auth/approle/role/vault-secrets-operator/role-id
+
+# Create a new secret for AppRole:
+vault write -f auth/approle/role/vault-secrets-operator/secret-id
+```
+
+Use the following commands to set the environment variables for the activation of the AppRole auth method:
+```shell
+export VAULT_AUTH_METHOD=approle
+export VAULT_ROLE_ID=
+export VAULT_SECRET_ID=
+export VAULT_TOKEN_MAX_TTL=86400
+```
+
+When you deploy the Vault Secrets Operator via Helm chart you have to set the `vault.authMethod` property to `approle` in the `values.yaml` file, to use the AppRole auth method instead of the default Token auth method.
+
+```yaml
+vault:
+  authMethod: approle
+```
+
 ## Usage
 
 Create two Vault secrets `example-vaultsecret`:

--- a/charts/README.md
+++ b/charts/README.md
@@ -13,10 +13,11 @@
 | `fullnameOverride` | Override the name of the app. | `""` |
 | `environmentVars` | Pass environment variables from a secret to the containers. This must be used if you use the Token auth method of Vault. | `[]` |
 | `vault.address` | The address where Vault listen on (e.g. `http://vault.example.com`). | `"http://vault:8200"` |
-| `vault.authMethod` | The authentication method, which should be used by the operator. Can by `token` ([Token auth method](https://www.vaultproject.io/docs/auth/token.html)) or `kubernetes` ([Kubernetes auth method](https://www.vaultproject.io/docs/auth/kubernetes.html)). | `token` |
+| `vault.authMethod` | The authentication method, which should be used by the operator. Can by `token` ([Token auth method](https://www.vaultproject.io/docs/auth/token.html)), `kubernetes` ([Kubernetes auth method](https://www.vaultproject.io/docs/auth/kubernetes.html)), or `approle` ([AppRole auth method](https://www.vaultproject.io/docs/auth/approle)). | `token` |
 | `vault.tokenPath` | Path to file with the Vault token if the used auth method is `token`. Can be used to read the token from a file and not from the  `VAULT_TOKEN` environment variable. | `""` |
 | `vault.kubernetesPath` | If the Kubernetes auth method is used, this is the path where the Kubernetes auth method is enabled. | `auth/kubernetes` |
 | `vault.kubernetesRole` | The name of the role which is configured for the Kubernetes auth method. | `vault-secrets-operator` |
+| `vault.appRolePath` | If the AppRole auth method is used, this is the path where the AppRole auth method is enabled. | `auth/approle` |
 | `vault.reconciliationTime` | The time after which the reconcile function for the CR is rerun. If the value is 0, automatic reconciliation is skipped. | `0` |
 | `vault.namespaces` | Comma serpareted list of namespaces the operator will watch. If empty the operator will watch all namespaces. | `""` |
 | `crd.create` | Create the custom resource definition. | `true` |

--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -56,6 +56,8 @@ spec:
               value: {{ .Values.vault.kubernetesPath | quote }}
             - name: VAULT_KUBERNETES_ROLE
               value: {{ .Values.vault.kubernetesRole | quote }}
+            - name: VAULT_APP_ROLE_PATH
+              value: {{ .Values.vault.appRolePath | quote }}
             - name: VAULT_RECONCILIATION_TIME
               value: {{ .Values.vault.reconciliationTime | quote }}
             {{- with .Values.environmentVars }}

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -15,7 +15,9 @@ fullnameOverride: ""
 
 environmentVars: []
   # Set environment variables from a secret. This must be done, if you use the
-  # Token Auth Method of Vault.
+  # Token or AppRole Auth Methods of Vault.
+
+  # Token auth method:
   # - name: VAULT_TOKEN
   #   valueFrom:
   #     secretKeyRef:
@@ -30,20 +32,48 @@ environmentVars: []
   # - name: VAULT_TOKEN_RENEWAL_RETRY_INTERVAL
   #   value: "30"
 
+  # AppRole auth method:
+  # - envName: VAULT_ROLE_ID
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: vault-secrets-operator
+  #       key: VAULT_ROLE_ID
+  # - envName: VAULT_SECRET_ID
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: vault-secrets-operator
+  #       key: VAULT_SECRET_ID
+  # - name: VAULT_TOKEN_RENEWAL_RETRY_INTERVAL
+  #   value: "30"
+  # - name: VAULT_TOKEN_MAX_TTL
+  #   value: "43200"
+
 # Set the address for vault (by default we assume you are running a dev
 # instance of vault in the same namespace as the operator) and specify the
-# authentication method for the operator.  Possible values are 'token' or
-# 'kubernetes'. If the authentication method is 'kubernetes' the Helm chart
+# authentication method for the operator.  Possible values are 'token',
+# 'kubernetes', or 'approle'.
+
+# If the authentication method is 'kubernetes' the Helm chart
 # ensures that the Service Account included the needed rights. The default path
 # for the Kubernets Auth method is 'auth/kubernetes', if you enabled it under
 # another path you must change the 'kubernetesPath' value. You must also
 # provide the role which should be used for the authentication.
+#
 # If the auth method is 'token' you can specify the 'tokenPath' to read the
 # Vault token from a mounted volume instead of an environment variable.
+#
+# If the auth method is 'approle' you must specify a path for the AppRole Auth
+# method with 'appRolePath', by default it is 'auth/approle'. Also
+# 'VAULT_ROLE_ID' and 'VAULT_SECRET_ID' must be set for this auth method. With
+# this method, the renewal interval is set by default to a half of the token
+# lease duration (can be overwritten with 'VAULT_TOKEN_RENEWAL_INTERVAL'), the
+# token maximum TTL is set by default to 1382400 seconds (16 days, can be
+# overwritten with 'VAULT_TOKEN_MAX_TTL').
+#
 # The reconciliationTime value determines after which time the Vault secret is
 # processed again. This can be used to update a the Kubernetes secret, when the
 # Vault secret changes. A value of 0 will disable the automatic update.
-# You can specify all namespaces the operator should watch. Therefor pass a
+# You can specify all namespaces the operator should watch. Therefore pass a
 # comma separated list via the namespaces value. If the value is empty the operator
 # will watch all namespaces. Namespaces are ignored if rbac.namespaced is set to
 # true, then the namespace of the release will be used
@@ -53,6 +83,7 @@ vault:
   tokenPath: ""
   kubernetesPath: auth/kubernetes
   kubernetesRole: vault-secrets-operator
+  appRolePath: auth/approle
   reconciliationTime: 0
   namespaces: ""
 

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -33,12 +33,12 @@ environmentVars: []
   #   value: "30"
 
   # AppRole auth method:
-  # - envName: VAULT_ROLE_ID
+  # - name: VAULT_ROLE_ID
   #   valueFrom:
   #     secretKeyRef:
   #       name: vault-secrets-operator
   #       key: VAULT_ROLE_ID
-  # - envName: VAULT_SECRET_ID
+  # - name: VAULT_SECRET_ID
   #   valueFrom:
   #     secretKeyRef:
   #       name: vault-secrets-operator

--- a/testbin/setup-kind-approle.sh
+++ b/testbin/setup-kind-approle.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+# Create registry container unless it already exists
+reg_name='kind-registry'
+reg_port='5000'
+running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+if [ "${running}" != 'true' ]; then
+  docker run \
+    -d --restart=always -p "${reg_port}:5000" --name "${reg_name}" \
+    registry:2
+fi
+
+# Create a cluster with the local registry enabled in containerd
+cat <<EOF | kind create cluster --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+    endpoint = ["http://${reg_name}:${reg_port}"]
+EOF
+
+# Connect the registry to the cluster network (the network may already be connected)
+docker network connect "kind" "${reg_name}" || true
+
+# Document the local registry
+# https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${reg_port}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF
+
+# Build the image for the operator and push the image to our local registry
+docker build . -t localhost:5000/vault-secrets-operator:test
+docker push localhost:5000/vault-secrets-operator:test
+
+kubectl create ns vault
+kubectl create ns vault-secrets-operator
+
+# Install Vault in the cluster and create a new secret engine for the operator
+helm repo add hashicorp https://helm.releases.hashicorp.com
+helm upgrade --install vault hashicorp/vault --namespace=vault --version=0.9.1 --set server.dev.enabled=true --set injector.enabled=false --set server.image.tag="1.6.2"
+
+sleep 10s
+kubectl wait pod/vault-0 --namespace=vault  --for=condition=Ready --timeout=180s
+kubectl port-forward --namespace vault vault-0 8200 &
+sleep 10s
+
+vault login root
+vault secrets enable -path=kvv2 -version=2 kv
+cat <<EOF | vault policy write vault-secrets-operator -
+path "kvv2/data/*" {
+  capabilities = ["read"]
+}
+EOF
+
+# Enable Vault AppRole auth method
+vault auth enable approle
+
+# Create new AppRole
+vault write auth/approle/role/vault-secrets-operator token_policies=vault-secrets-operator
+
+# Get AppRole ID and secret ID
+VAULT_ROLE_ID=$(vault read auth/approle/role/vault-secrets-operator/role-id -format=json | jq -r .data.role_id)
+VAULT_SECRET_ID=$(vault write -f auth/approle/role/vault-secrets-operator/secret-id -format=json | jq -r .data.secret_id)
+
+cat <<EOF > ./vault-secrets-operator.env
+VAULT_ROLE_ID=$VAULT_ROLE_ID
+VAULT_SECRET_ID=$VAULT_SECRET_ID
+EOF
+
+kubectl create secret generic vault-secrets-operator \
+  --namespace=vault-secrets-operator \
+  --from-env-file=./vault-secrets-operator.env
+
+cat <<EOF > ./values.yaml
+vault:
+  address: http://vault.vault.svc.cluster.local:8200
+  authMethod: approle
+image:
+  repository: localhost:5000/vault-secrets-operator
+  tag: test
+environmentVars:
+  - name: VAULT_ROLE_ID
+    valueFrom:
+      secretKeyRef:
+        name: vault-secrets-operator
+        key: VAULT_ROLE_ID
+  - name: VAULT_SECRET_ID
+    valueFrom:
+      secretKeyRef:
+        name: vault-secrets-operator
+        key: VAULT_SECRET_ID
+EOF
+
+helm upgrade --install vault-secrets-operator ./charts/vault-secrets-operator --namespace=vault-secrets-operator -f ./values.yaml
+
+vault kv put kvv2/helloworld foo=bar
+
+cat <<EOF | kubectl apply -f -
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: helloworld
+spec:
+  vaultRole: vault-secrets-operator
+  path: kvv2/helloworld
+  type: Opaque
+EOF
+
+kubectl wait pod --namespace=vault-secrets-operator -l app.kubernetes.io/instance=vault-secrets-operator --for=condition=Ready --timeout=180s
+sleep 10s
+kubectl get secret helloworld -o yaml
+kubectl logs --namespace=vault-secrets-operator -l app.kubernetes.io/instance=vault-secrets-operator

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -59,6 +59,10 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 	vaultTokenRenewalInterval := os.Getenv("VAULT_TOKEN_RENEWAL_INTERVAL")
 	vaultTokenRenewalRetryInterval := os.Getenv("VAULT_TOKEN_RENEWAL_RETRY_INTERVAL")
 	vaultKubernetesPath := os.Getenv("VAULT_KUBERNETES_PATH")
+	vaultAppRolePath := os.Getenv("VAULT_APP_ROLE_PATH")
+	vaultRoleID := os.Getenv("VAULT_ROLE_ID")
+	vaultSecretID := os.Getenv("VAULT_SECRET_ID")
+	vaultTokenMaxTTL := os.Getenv("VAULT_TOKEN_MAX_TTL")
 
 	// Create new Vault configuration. This configuration is used to create the
 	// API client. We set the timeout of the HTTP client to 10 seconds.
@@ -178,6 +182,79 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 			tokenLeaseDuration:        tokenLeaseDuration,
 			tokenRenewalInterval:      tokenRenewalInterval,
 			tokenRenewalRetryInterval: tokenRenewalRetryInterval,
+		}, nil
+	}
+
+	if vaultAuthMethod == "approle" {
+		if vaultRoleID == "" {
+			return nil, fmt.Errorf("missing role id for AppRole auth method")
+		}
+		if vaultSecretID == "" {
+			return nil, fmt.Errorf("missing secret id for AppRole auth method")
+		}
+
+		appRolePath := "auth/approle"
+		if vaultAppRolePath != "" {
+			appRolePath = vaultAppRolePath
+		}
+
+		data := make(map[string]interface{})
+		data["role_id"] = vaultRoleID
+		data["secret_id"] = vaultSecretID
+
+		// Authenticate against vault using the AppRole Auth Method and set
+		// the token which the client should use for further interactions with
+		// Vault. We also set the lease duration of the token for the renew
+		// function.
+		secret, err := apiClient.Logical().Write(appRolePath+"/login", data)
+		if err != nil {
+			return nil, err
+		} else if secret.Auth == nil {
+			return nil, fmt.Errorf("missing authentication information")
+		}
+
+		tokenLeaseDuration := secret.Auth.LeaseDuration
+
+		tokenRenewalInterval, err := strconv.ParseFloat(vaultTokenRenewalInterval, 64)
+		if err != nil {
+			tokenRenewalInterval = float64(tokenLeaseDuration) * 0.5
+		}
+
+		tokenRenewalRetryInterval, err := strconv.ParseFloat(vaultTokenRenewalRetryInterval, 64)
+		if err != nil {
+			tokenRenewalRetryInterval = 30.0
+		}
+
+		tokenMaxTTL, err := strconv.Atoi(vaultTokenMaxTTL)
+		if err != nil {
+			// Vault default max TTL is 32 days, use 16 days as the reasonable default if
+			// VAULT_TOKEN_MAX_TTL not set.
+			// https://learn.hashicorp.com/tutorials/vault/tokens
+			tokenMaxTTL = 16 * 24 * 60 * 60
+		}
+
+		apiClient.SetToken(secret.Auth.ClientToken)
+
+		return &Client{
+			client:                    apiClient,
+			tokenLeaseDuration:        tokenLeaseDuration,
+			tokenRenewalInterval:      tokenRenewalInterval,
+			tokenRenewalRetryInterval: tokenRenewalRetryInterval,
+			tokenMaxTTL:               tokenMaxTTL,
+			requestToken: func(c *Client) error {
+				secret, err := apiClient.Logical().Write(appRolePath+"/login", data)
+				if err != nil {
+					return err
+				}
+				c.client.SetToken(secret.Auth.ClientToken)
+				// Update token lease duration and renewal interval
+				c.tokenLeaseDuration = secret.Auth.LeaseDuration
+				c.tokenRenewalInterval, err = strconv.ParseFloat(vaultTokenRenewalInterval, 64)
+				if err != nil {
+					c.tokenRenewalInterval = float64(c.tokenLeaseDuration) * 0.5
+				}
+				return nil
+			},
 		}, nil
 	}
 


### PR DESCRIPTION
Adding a new Vault auth method `approle` that requires `VAULT_ROLE_ID`
and `VAULT_SECRET_ID` instead of the token. Also added a new parameter
`VAULT_APP_ROLE_PATH`, which is set to `auth/approle` in Helm chart by
default. Also, tokens returned by AppRole auth method usually have a
maximum TTL, by default 32 days, so the operator needs to request a new
token periodically using AppRole id and secret id. To control the token
maximum TTL, added a new parameter `VAULT_TOKEN_MAX_TTL`, which by
default set to 1382400 seconds (16 days).