### PR TITLE
Fix RBAC for namespaced deployments

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        test: [kubernetes-sharedclient, kubernetes-nosharedclient]
+        test: [kubernetes-sharedclient, kubernetes-nosharedclient, kubernetes-namespaced]
     defaults:
       run:
         shell: bash

--- a/charts/README.md
+++ b/charts/README.md
@@ -20,8 +20,8 @@
 | `vault.reconciliationTime` | The time after which the reconcile function for the CR is rerun. If the value is 0, automatic reconciliation is skipped. | `0` |
 | `vault.namespaces` | Comma serpareted list of namespaces the operator will watch. If empty the operator will watch all namespaces. | `""` |
 | `crd.create` | Create the custom resource definition. | `true` |
-| `rbac.create` | Create RBAC object, enable ClusterRole and (Cluster)Role binding creation. | `true` |
-| `rbac.createclusterrole` | Finetune RBAC, enable or disable ClusterRole creation. NOTE: ignored when `rbac.create` not `true`. | `true` |
+| `rbac.create` | Create RBAC object, enable (Cluster)Role and (Cluster)Role binding creation. | `true` |
+| `rbac.createrole` | Finetune RBAC, enable or disable (Cluster)Role creation. NOTE: ignored when `rbac.create` is not `true`. | `true` |
 | `rbac.namespaced` | Deploy in isolated namespace. Creates RoleBinding instead of a ClusterRoleBinding | `false` |
 | `serviceAccount.create` | Create the service account. | `true` |
 | `serviceAccount.name` | The name of the service account, which should be created/used by the operator. | `vault-secrets-operator` |

--- a/charts/vault-secrets-operator/templates/_helpers.tpl
+++ b/charts/vault-secrets-operator/templates/_helpers.tpl
@@ -71,23 +71,3 @@ Create the name of the service account to use.
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
-
-{{/*
-Inject the necessary rules for the Service Account, if the authentication method is 'kubernetes'.
-*/}}
-{{- define "vault-secrets-operator.kubernetesAuthRules" -}}
-{{- if eq .Values.vault.authMethod "kubernetes" -}}
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
-{{- end -}}
-{{- end -}}

--- a/charts/vault-secrets-operator/templates/cluster-role-binding.yaml
+++ b/charts/vault-secrets-operator/templates/cluster-role-binding.yaml
@@ -1,6 +1,6 @@
 {{ if and .Values.rbac.create (eq .Values.vault.authMethod "kubernetes") }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: {{ if not .Values.rbac.namespaced -}} Cluster {{- end -}} RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: {{ template "vault-secrets-operator.fullname" . }}-{{ .Release.Namespace }}
   labels:

--- a/charts/vault-secrets-operator/templates/cluster-role-binding.yaml
+++ b/charts/vault-secrets-operator/templates/cluster-role-binding.yaml
@@ -1,0 +1,17 @@
+{{ if and .Values.rbac.create (eq .Values.vault.authMethod "kubernetes") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ if not .Values.rbac.namespaced -}} Cluster {{- end -}} RoleBinding
+metadata:
+  name: {{ template "vault-secrets-operator.fullname" . }}-{{ .Release.Namespace }}
+  labels:
+{{ include "vault-secrets-operator.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vault-secrets-operator-{{ .Release.Namespace }}
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ template "vault-secrets-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/charts/vault-secrets-operator/templates/cluster-role.yaml
+++ b/charts/vault-secrets-operator/templates/cluster-role.yaml
@@ -1,81 +1,21 @@
-{{ if and .Values.rbac.create .Values.rbac.createclusterrole }}
+{{ if and .Values.rbac.create (eq .Values.vault.authMethod "kubernetes") }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind:  ClusterRole
 metadata:
-  name: vault-secrets-operator
+  name: vault-secrets-operator-{{ .Release.Namespace }}
   labels:
 {{ include "vault-secrets-operator.labels" . | indent 4 }}
 rules:
-{{ include "vault-secrets-operator.kubernetesAuthRules" . | indent 2 }}
   - apiGroups:
-    - ""
+    - authentication.k8s.io
     resources:
-    - configmaps
+    - tokenreviews
     verbs:
     - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
   - apiGroups:
-    - ""
+    - authorization.k8s.io
     resources:
-    - configmaps/status
-    verbs:
-    - get
-    - patch
-    - update
-  - apiGroups:
-    - ""
-    resources:
-    - events
+    - subjectaccessreviews
     verbs:
     - create
-    - patch
-  - apiGroups:
-    - ""
-    resources:
-    - secrets
-    verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - ricoberger.de
-    resources:
-    - vaultsecrets
-    verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - ricoberger.de
-    resources:
-    - vaultsecrets/finalizers
-    verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - ricoberger.de
-    resources:
-    - vaultsecrets/status
-    verbs:
-    - get
-    - patch
-    - update
 {{ end }}

--- a/charts/vault-secrets-operator/templates/role-binding.yaml
+++ b/charts/vault-secrets-operator/templates/role-binding.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "vault-secrets-operator.labels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: {{ if not .Values.rbac.namespaced -}} Cluster {{- end -}} Role
   name: vault-secrets-operator
 subjects:
   - apiGroup: ""

--- a/charts/vault-secrets-operator/templates/role.yaml
+++ b/charts/vault-secrets-operator/templates/role.yaml
@@ -1,0 +1,80 @@
+{{ if and .Values.rbac.create .Values.rbac.createrole }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind:  {{ if not .Values.rbac.namespaced -}} Cluster {{- end -}} Role
+metadata:
+  name: vault-secrets-operator
+  labels:
+{{ include "vault-secrets-operator.labels" . | indent 4 }}
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps/status
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ricoberger.de
+    resources:
+    - vaultsecrets
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ricoberger.de
+    resources:
+    - vaultsecrets/finalizers
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ricoberger.de
+    resources:
+    - vaultsecrets/status
+    verbs:
+    - get
+    - patch
+    - update
+{{ end }}

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -61,7 +61,7 @@ crd:
 
 rbac:
   create: true
-  createclusterrole: true
+  createrole: true
   namespaced: false
 
 serviceAccount:

--- a/testbin/setup-kind-kubernetes-namespaced.sh
+++ b/testbin/setup-kind-kubernetes-namespaced.sh
@@ -64,7 +64,7 @@ path "kvv2/data/*" {
 EOF
 vault kv put kvv2/helloworld foo=bar
 
-helm upgrade --install vault-secrets-operator ./charts/vault-secrets-operator --namespace=vault-secrets-operator --set vault.address="http://vault.vault.svc.cluster.local:8200" --set vault.authMethod="kubernetes" --set image.repository="localhost:5000/vault-secrets-operator" --set image.tag="test"
+helm upgrade --install vault-secrets-operator ./charts/vault-secrets-operator --namespace=vault-secrets-operator --set vault.address="http://vault.vault.svc.cluster.local:8200" --set vault.authMethod="kubernetes" --set image.repository="localhost:5000/vault-secrets-operator" --set image.tag="test" --set rbac.namespaced="true"
 
 export VAULT_SECRETS_OPERATOR_NAMESPACE=$(kubectl get sa --namespace=vault-secrets-operator vault-secrets-operator -o jsonpath="{.metadata.namespace}")
 export VAULT_SECRET_NAME=$(kubectl get sa --namespace=vault-secrets-operator vault-secrets-operator -o jsonpath="{.secrets[*]['name']}")
@@ -81,6 +81,7 @@ apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:
   name: helloworld
+  namespace: vault-secrets-operator
 spec:
   path: kvv2/helloworld
   type: Opaque
@@ -91,5 +92,5 @@ kubectl wait pod --namespace=vault-secrets-operator -l app.kubernetes.io/instanc
 kubectl delete pod --namespace=vault-secrets-operator -l app.kubernetes.io/instance=vault-secrets-operator
 kubectl wait pod --namespace=vault-secrets-operator -l app.kubernetes.io/instance=vault-secrets-operator --for=condition=Ready --timeout=180s
 sleep 10s
-kubectl get secret helloworld -o yaml
+kubectl get secret --namespace=vault-secrets-operator helloworld -o yaml
 kubectl logs --namespace=vault-secrets-operator -l app.kubernetes.io/instance=vault-secrets-operator

--- a/testbin/setup-kind-kubernetes-nosharedclient.sh
+++ b/testbin/setup-kind-kubernetes-nosharedclient.sh
@@ -93,4 +93,4 @@ kubectl delete pod --namespace=vault-secrets-operator -l app.kubernetes.io/insta
 kubectl wait pod --namespace=vault-secrets-operator -l app.kubernetes.io/instance=vault-secrets-operator --for=condition=Ready --timeout=180s
 sleep 10s
 kubectl get secret helloworld -o yaml
-kubectl  logs --namespace=vault-secrets-operator -l app.kubernetes.io/instance=vault-secrets-operator
+kubectl logs --namespace=vault-secrets-operator -l app.kubernetes.io/instance=vault-secrets-operator


### PR DESCRIPTION
Fix RBAC permissions for namespaced deployments, when the Kubernetes authentication method is used. When the Kubernetes auth method is used for the operator, we have to create an additional ClusterRole and ClusterRoleBinding for the TokenReview API.

:warning: Breaking: :warning: `createclusterrole` was renamed to `createrole`, because we are creating a Role instead of a ClusterRole, when the `rbac. namespaced` value is set to true. So that the (Cluster)Role is handle in the same way as the (Cluster)RoleBinding.

Fixes #81.