### PR TITLE
Adds an init container to the Helm chart to wait for Vault

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -39,3 +39,9 @@
 | `serviceMonitor.honorLabels` | Honor labels option. | `true` |
 | `serviceMonitor.relabelings` | Additional relabeling config for the ServiceMonitor. | `[]` |
 | `priorityClassName` | Optionally attach priority class to pod spec. | `null` |
+| `initContainer.enabled` | Enable the creation of an init container to wait until Vault is available before starting. | `false` |
+| `initContainer.vaultService` | The name of the Vault service to wait for. | `vault-active` |
+| `initContainer.vaultNamespace` | The namespace in which the Vault service is located. | `default` |
+| `initContainer.repository` | The repository of the init container Docker image. | `busybox` |
+| 'initContainer.tag` | The tag of the init container Docker image which should be used.` | `stable` |
+

--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -31,6 +31,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ template "vault-secrets-operator.serviceAccountName" . }}
+      {{- if .Values.initContainer.enabled }}
+      initContainers:
+        - name: wait-for-vault
+          image: "{{ .Values.initContainer.repository }}:{{ .Values.initContainer.tag }}"
+          command: ['sh', '-c', 'until nslookup {{ .Values.initContainer.vaultService }}.{{ .Values.initContainer.vaultNamespace }}.svc.cluster.local; do echo waiting for Vault; sleep 2; done;']
+      {{- end}} 
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -141,3 +141,10 @@ serviceMonitor:
 
 # A priority class can be optionally attached to the pod spec if one is needed
 # priorityClassName: high
+
+initContainer:
+  enabled: false
+  vaultService: vault-active
+  vaultNamespace: default
+  repository: busybox
+  tag: stable


### PR DESCRIPTION
This PR modifies the Helm chart to add an init container which waits for Vault to become available (by polling for the presence of the relevant service in the cluster DNS) before existing and allowing the Vault secrets operator to start.

I've found this to be useful on my own clusters since it prevents the Vault secrets operator container from ending up in CrashLoopBackOff state while waiting for a restarted/migrated Vault to be unsealed, and thus being slow or requiring manual intervention to kick into motion once Vault is unsealed.

Thought I'd contribute it for anyone else who might find it useful.
