### PR TITLE
Allow setting a list of namespaces even when rbac.namespaced is true

### DIFF
--- a/charts/vault-secrets-operator/Chart.yaml
+++ b/charts/vault-secrets-operator/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: Rico Berger
     url: https://ricoberger.de
 name: vault-secrets-operator
-version: 1.13.0
+version: 1.13.1

--- a/charts/vault-secrets-operator/Chart.yaml
+++ b/charts/vault-secrets-operator/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: Rico Berger
     url: https://ricoberger.de
 name: vault-secrets-operator
-version: 1.13.1
+version: 1.13.0

--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -41,10 +41,12 @@ spec:
             - --enable-leader-election
           env:
             - name: WATCH_NAMESPACE
-            {{- if .Values.rbac.namespaced }}
+            {{- if .Values.vault.namespaces }}
+              value: {{ .Values.vault.namespaces | quote }}
+            {{- else if .Values.rbac.namespaced }}
               value: {{ .Release.Namespace | quote }}
             {{- else }}
-              value: {{ .Values.vault.namespaces | quote }}
+              value: ""
             {{- end }}
             - name: VAULT_ADDRESS
               value: {{ .Values.vault.address | quote }}

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -75,8 +75,8 @@ environmentVars: []
 # Vault secret changes. A value of 0 will disable the automatic update.
 # You can specify all namespaces the operator should watch. Therefore pass a
 # comma separated list via the namespaces value. If the value is empty the operator
-# will watch all namespaces. Namespaces are ignored if rbac.namespaced is set to
-# true, then the namespace of the release will be used
+# will watch all namespaces. If the value is empty and rbac.namespaced is set to
+# true, then the namespace of the release will be used.
 vault:
   address: "http://vault:8200"
   authMethod: token


### PR DESCRIPTION
This is for an edge case in a multi-tenant environment when there can't be a ClusterRole created.

In those cases, we set `rbac.namespaced: "true"` so that it creates a Role. Then in each specified namespace we, out of band from this chart, create the RBAC rules that allow the operator to watch those namespaces as well as the one it is deployed in.

This change makes it so that in that scenario the operator can watch the specified namespaces without creating a ClusterRole.

Please let me know if you need a more detailed example of our environment & deployment and why this change will help us.