### PR TITLE
Add ARM Support

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,6 +1,12 @@
 name: Docker
 
-on: push
+on:
+  push:
+    branches:
+      - master
+      - dev
+    tags:
+      - '*'
 
 jobs:
   docker:
@@ -14,11 +20,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
-      - name: Setup Go 1.15
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.15
 
       - name: Set Docker Tag
         id: tag
@@ -34,13 +35,25 @@ jobs:
           fi
           echo ::set-output name=tag::${DOCKER_TAG}
 
-      - name: Build Docker Image
-        run: make docker-build IMG=ricoberger/vault-secrets-operator:${{ steps.tag.outputs.tag }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
 
-      - name: Login to Docker Hub
-        if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
-        run: docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
-      - name: Push Docker Image
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and Push Docker Image
         if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
-        run: make docker-push IMG=ricoberger/vault-secrets-operator:${{ steps.tag.outputs.tag }}
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: .
+          file: ./Dockerfile
+          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8
+          tags: ricoberger/vault-secrets-operator:${{ steps.tag.outputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,12 @@ COPY controllers/ controllers/
 COPY vault/ vault/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GO111MODULE=on go build -a -o manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM alpine:3.13.0
+RUN apk update && apk add --no-cache ca-certificates
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER nonroot:nonroot
+USER nobody
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Add support for ARM. The Docker image is now available for: `linux/386`, `linux/amd64`, `linux/arm/v6`, `linux/arm/v7` and `linux/arm64/v8`.

Closes #92.