### PR TITLE
fix helm test port

### DIFF
--- a/charts/vault-secrets-operator/templates/tests/test-connection.yaml
+++ b/charts/vault-secrets-operator/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args:  ['{{ include "vault-secrets-operator.fullname" . }}:8686']
+      args:  ['{{ include "vault-secrets-operator.fullname" . }}:8081']
   restartPolicy: Never


### PR DESCRIPTION
A few releases back http metrics port was from from 8686 to 8081 the helm test has not passed since. 