### PR TITLE
Add support for access vault namespace root secrets

### DIFF
--- a/vault/client.go
+++ b/vault/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -32,6 +31,8 @@ type Client struct {
 	tokenMaxTTL int
 	// requestToken is a function to request a new Vault token, specific for auth method.
 	requestToken RequestToken
+	// vault namespace
+	rootVaultNamespace string
 }
 
 // RenewToken renews the provided token after the half of the lease duration is
@@ -42,9 +43,8 @@ func (c *Client) RenewToken() {
 		// Set the namespace to the value from the VAULT_NAMESPACE environment
 		// variable, because the namespace will always change, when a secret is
 		// requested.
-		rootVaultNamespace := os.Getenv("VAULT_NAMESPACE")
-		if rootVaultNamespace != "" {
-			c.client.SetNamespace(rootVaultNamespace)
+		if c.rootVaultNamespace != "" {
+			c.client.SetNamespace(c.rootVaultNamespace)
 		}
 
 		// Request a new token if the actual token lifetime more than the specified maximum
@@ -86,18 +86,20 @@ func (c *Client) GetSecret(secretEngine string, path string, keys []string, vers
 	// Check if the vaultNamespace field is set for the secret. If the field is
 	// set we use the configured root namespace from the VAULT_NAMESPACE and
 	// the value from the vaultNamespace field to build the final namespace
-	// path.
+	// path. If the field is not set but VAULT_NAMESPACE has a value, we
+	// just use the latter.
 	// If the vaultNamespace field is set, but not the VAULT_NAMESPACE
 	// environment variable we return an error, because the authentication
 	// already failed.
-	if vaultNamespace != "" {
-		rootVaultNamespace := os.Getenv("VAULT_NAMESPACE")
-		if rootVaultNamespace != "" {
-			log.WithValues("rootVaultNamespace", rootVaultNamespace, "vaultNamespace", vaultNamespace).Info(fmt.Sprintf("Use Vault Namespace to read secret %s", path))
-			c.client.SetNamespace(rootVaultNamespace + "/" + vaultNamespace)
+	if c.rootVaultNamespace != "" {
+		log.WithValues("rootVaultNamespace", c.rootVaultNamespace, "vaultNamespace", vaultNamespace).Info(fmt.Sprintf("Use Vault Namespace to read secret %s", path))
+		if vaultNamespace != "" {
+			c.client.SetNamespace(c.rootVaultNamespace + "/" + vaultNamespace)
 		} else {
-			return nil, fmt.Errorf("vaultNamespace field can not be used, because the VAULT_NAMESPACE environment variable is not set")
+			c.client.SetNamespace(c.rootVaultNamespace)
 		}
+	} else if c.rootVaultNamespace == "" && vaultNamespace != "" {
+		return nil, fmt.Errorf("vaultNamespace field can not be used, because the VAULT_NAMESPACE environment variable is not set")
 	}
 
 	// Check if the KVv1 or KVv2 is used for the provided secret and determin

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -63,6 +63,7 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 	vaultRoleID := os.Getenv("VAULT_ROLE_ID")
 	vaultSecretID := os.Getenv("VAULT_SECRET_ID")
 	vaultTokenMaxTTL := os.Getenv("VAULT_TOKEN_MAX_TTL")
+	vaultNamespace := os.Getenv("VAULT_NAMESPACE")
 
 	// Create new Vault configuration. This configuration is used to create the
 	// API client. We set the timeout of the HTTP client to 10 seconds.
@@ -124,6 +125,7 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 			tokenLeaseDuration:        tokenLeaseDuration,
 			tokenRenewalInterval:      tokenRenewalInterval,
 			tokenRenewalRetryInterval: tokenRenewalRetryInterval,
+			rootVaultNamespace:        vaultNamespace,
 		}, nil
 	}
 
@@ -182,6 +184,7 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 			tokenLeaseDuration:        tokenLeaseDuration,
 			tokenRenewalInterval:      tokenRenewalInterval,
 			tokenRenewalRetryInterval: tokenRenewalRetryInterval,
+			rootVaultNamespace:        vaultNamespace,
 		}, nil
 	}
 
@@ -241,6 +244,7 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 			tokenRenewalInterval:      tokenRenewalInterval,
 			tokenRenewalRetryInterval: tokenRenewalRetryInterval,
 			tokenMaxTTL:               tokenMaxTTL,
+			rootVaultNamespace:        vaultNamespace,
 			requestToken: func(c *Client) error {
 				secret, err := apiClient.Logical().Write(appRolePath+"/login", data)
 				if err != nil {


### PR DESCRIPTION
with the previous behavior, if `vaultNamespace` was not passed in the `VaultSecret` resource, but the `vault-secrets-operator` was initialized with a `VAULT_NAMESPACE`, no namespace would be passed and the `getSecret` operation would fail. Any other value of `vaultNamespace` would fail with these error:

if `vaultNamespace: "/"`
```
export VAULT_NAMESPACE=root/namespace//

$ vault kv get kv/mysecret
invalid character '<' looking for beginning of value 
```

if `vaultNamespace: "."`
```
export VAULT_NAMESPACE=root/namespace/.

$ vault kv get kv/mysecret
invalid character '<' looking for beginning of value 
```

if `vaultNamespace: ""`
The `c.client.SetNamespace(c.rootVaultNamespace + "/" + vaultNamespace)` call is skipped

The change sets the VAULT_NAMESPACE as a set variable (less `os.Getenv()` calls) and checks it first before appending `/<vaultNamespace>` or not