### PR TITLE
fix return code on health check

### DIFF
--- a/charts/vault-secrets-operator/templates/tests/test-connection.yaml
+++ b/charts/vault-secrets-operator/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args:  ['{{ include "vault-secrets-operator.fullname" . }}:8081']
+      args:  ['{{ include "vault-secrets-operator.fullname" . }}:8081/healthz']
   restartPolicy: Never


### PR DESCRIPTION
Sorry my last PR didnt fully fix the issue, the path `/` is kicking back a 404 which fails the test anyways.

Its my fault, i should have ran the test with a proper install.

Without `healthz`
```
wget localhost:8081/ ; echo $?
--2021-04-02 14:04:19--  http://localhost:8081/
Resolving localhost (localhost)... 127.0.0.1
Connecting to localhost (localhost)|127.0.0.1|:8081... connected.
HTTP request sent, awaiting response... 404 Not Found
2021-04-02 14:04:20 ERROR 404: Not Found.

8

```

With `healthz`
```
wget localhost:8081/healthz ; echo $?
--2021-04-02 14:03:47--  http://localhost:8081/healthz
Resolving localhost (localhost)... 127.0.0.1
Connecting to localhost (localhost)|127.0.0.1|:8081... connected.
HTTP request sent, awaiting response... 200 OK
Length: 2 [text/plain]
Saving to: ‘healthz.4’

healthz.4                                 100%[===================================================================================>]       2  --.-KB/s    in 0s      

2021-04-02 14:03:47 (125 KB/s) - ‘healthz’ saved [2/2]

0
```