### PR TITLE
Fix nil pointer exception in renew token function

### DIFF
--- a/vault/client.go
+++ b/vault/client.go
@@ -69,7 +69,11 @@ func (c *Client) RenewToken() {
 			log.Error(err, "Could not renew token")
 
 			lookup, err := c.client.Auth().Token().LookupSelf()
-			log.WithValues("error", err.Error()).Info(fmt.Sprintf("Token information: %#v", lookup))
+			if err != nil {
+				log.WithValues("error", err.Error()).Info("LookupSelf failed")
+			} else {
+				log.Info(fmt.Sprintf("Token information: %#v", lookup))
+			}
 
 			time.Sleep(time.Duration(c.tokenRenewalRetryInterval) * time.Second)
 		} else {


### PR DESCRIPTION
Fix nil pointer exception in the renew token function, so that we can use tokens which can not be renewed again.

This means that the renew token request will still be triggered, but doesn't cause a crash for tokens, which can not be renewed.

The time between the renew requests can then be increase via the `VAULT_TOKEN_RENEWAL_RETRY_INTERVAL` environment variable, e.g. to 1 hour `VAULT_TOKEN_RENEWAL_RETRY_INTERVAL=3600`.

Closes #96 