### PR TITLE
Add testPodAnnotations and testPodLabels to test-connection hook

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -5,7 +5,7 @@
 | `replicaCount` | Number of replications which should be created. | `1` |
 | `deploymentStrategy` | Deployment strategy which should be used. | `{}` |
 | `image.repository` | The repository of the Docker image. | `ricoberger/vault-secrets-operator` |
-| `image.tag` | The tag of the Docker image which should be used. | `1.14.3` |
+| `image.tag` | The tag of the Docker image which should be used. | `1.14.2` |
 | `image.pullPolicy` | The pull policy for the Docker image, | `IfNotPresent` |
 | `image.volumeMounts` | Mount additional volumns to the container. | `[]` |
 | `imagePullSecrets` | Secrets which can be used to pull the Docker image. | `[]` |

--- a/charts/README.md
+++ b/charts/README.md
@@ -28,6 +28,8 @@
 | `serviceAccount.name` | The name of the service account, which should be created/used by the operator. | `vault-secrets-operator` |
 | `podAnnotations` | Annotations for vault-secrets-operator pod(s). | `{}` |
 | `podLabels` | Additional labels for the vault-secrets-operator pod(s). | `{}` |
+| `testPodAnnotations` | Annotations for vault-secrets-operator-test-connection pod. | `{}` |
+| `testPodLabels` | Additional labels for the vault-secrets-operator-test-connection pod. | `{}` |
 | `resources` | Set resources for the operator. | `{}` |
 | `volumes` | Provide additional volumns for the container. | `[]` |
 | `nodeSelector` | Set a node selector. | `{}` |

--- a/charts/README.md
+++ b/charts/README.md
@@ -5,7 +5,7 @@
 | `replicaCount` | Number of replications which should be created. | `1` |
 | `deploymentStrategy` | Deployment strategy which should be used. | `{}` |
 | `image.repository` | The repository of the Docker image. | `ricoberger/vault-secrets-operator` |
-| `image.tag` | The tag of the Docker image which should be used. | `1.14.2` |
+| `image.tag` | The tag of the Docker image which should be used. | `1.14.3` |
 | `image.pullPolicy` | The pull policy for the Docker image, | `IfNotPresent` |
 | `image.volumeMounts` | Mount additional volumns to the container. | `[]` |
 | `imagePullSecrets` | Secrets which can be used to pull the Docker image. | `[]` |

--- a/charts/vault-secrets-operator/Chart.yaml
+++ b/charts/vault-secrets-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.14.3
+appVersion: 1.14.2
 description: Create Kubernetes secrets from Vault for a secure GitOps based workflow.
 home: https://github.com/ricoberger/vault-secrets-operator
 icon: https://raw.githubusercontent.com/ricoberger/vault-secrets-operator/master/assets/logo.png
@@ -7,4 +7,4 @@ maintainers:
   - name: Rico Berger
     url: https://ricoberger.de
 name: vault-secrets-operator
-version: 1.14.3
+version: 1.14.2

--- a/charts/vault-secrets-operator/Chart.yaml
+++ b/charts/vault-secrets-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.14.2
+appVersion: 1.14.3
 description: Create Kubernetes secrets from Vault for a secure GitOps based workflow.
 home: https://github.com/ricoberger/vault-secrets-operator
 icon: https://raw.githubusercontent.com/ricoberger/vault-secrets-operator/master/assets/logo.png
@@ -7,4 +7,4 @@ maintainers:
   - name: Rico Berger
     url: https://ricoberger.de
 name: vault-secrets-operator
-version: 1.14.2
+version: 1.14.3

--- a/charts/vault-secrets-operator/templates/_helpers.tpl
+++ b/charts/vault-secrets-operator/templates/_helpers.tpl
@@ -62,6 +62,24 @@ Additional pod annotations
 {{- end -}}
 
 {{/*
+Additional test-connection pod annotations
+*/}}
+{{- define "vault-secrets-operator.testPodAnnotations" -}}
+{{- if .Values.testPodAnnotations }}
+{{- toYaml .Values.testPodAnnotations }}
+{{- end }}
+{{- end }}
+
+{{/*
+Additional test-connection pod labels
+*/}}
+{{- define "vault-secrets-operator.testPodLabels" -}}
+{{- if .Values.testPodLabels }}
+{{- toYaml .Values.testPodLabels }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use.
 */}}
 {{- define "vault-secrets-operator.serviceAccountName" -}}

--- a/charts/vault-secrets-operator/templates/tests/test-connection.yaml
+++ b/charts/vault-secrets-operator/templates/tests/test-connection.yaml
@@ -6,6 +6,7 @@ metadata:
 {{ include "vault-secrets-operator.labels" . | indent 4 }}
   annotations:
     "helm.sh/hook": test-success
+{{ include "vault-secrets-operator.annotations" . | indent 4 }}
 spec:
   containers:
     - name: wget

--- a/charts/vault-secrets-operator/templates/tests/test-connection.yaml
+++ b/charts/vault-secrets-operator/templates/tests/test-connection.yaml
@@ -4,9 +4,10 @@ metadata:
   name: "{{ include "vault-secrets-operator.fullname" . }}-test-connection"
   labels:
 {{ include "vault-secrets-operator.labels" . | indent 4 }}
+{{ include "vault-secrets-operator.testPodLabels" . | indent 4 }}
   annotations:
     "helm.sh/hook": test-success
-{{ include "vault-secrets-operator.annotations" . | indent 4 }}
+{{ include "vault-secrets-operator.testPodAnnotations" . | indent 4 }}
 spec:
   containers:
     - name: wget

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -105,6 +105,12 @@ podAnnotations: {}
 # Additional labels for the vault-secrets-operator pod(s).
 podLabels: {}
 
+# Annotations for the vault-secrets-operator-test-connection pod
+testPodAnnotations: {}
+
+# Additional labels for the vault-secrets-operator-test-connection pod
+testPodLabels: {}
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -3,7 +3,7 @@ deploymentStrategy: {}
 
 image:
   repository: ricoberger/vault-secrets-operator
-  tag: 1.14.2
+  tag: 1.14.3
   pullPolicy: IfNotPresent
   volumeMounts: []
     # - name: ca

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -3,7 +3,7 @@ deploymentStrategy: {}
 
 image:
   repository: ricoberger/vault-secrets-operator
-  tag: 1.14.3
+  tag: 1.14.2
   pullPolicy: IfNotPresent
   volumeMounts: []
     # - name: ca


### PR DESCRIPTION
@ricoberger What do you think about this? I'm deploying this helm chart via Spinnaker, and for resources that aren't natively versioned, Spinnaker appends a version to the resource name. So the test-connection pod now becomes xxx-test-connection-v000. To prevent this, Spinnaker allows you to [specify a pod annotation](https://spinnaker.io/reference/providers/kubernetes-v2/#strategy) to disable versioning in the pod name. 

I'd like to set the vault-secrets-operator value `testPodAnnotations` to include this spinnaker annotation (or any arbitrary annotation) and have it apply to the test-connection pod.