### PR TITLE
Support additional containers in deployment

### DIFF
--- a/charts/vault-secrets-operator/templates/_helpers.tpl
+++ b/charts/vault-secrets-operator/templates/_helpers.tpl
@@ -89,3 +89,9 @@ Create the name of the service account to use.
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Additional containers to add to the deployment
+*/}}
+{{- define "vault-secrets-operator.additionalContainers" -}}
+{{- end -}}

--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -90,6 +90,7 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- include "vault-secrets-operator.additionalContainers" . | nindent 8 }}
       {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
@ricoberger This PR allows parent charts to define a `vault-secrets-operator.additionalContainers` template to override a default empty string template that will be dropped in to the deployment yaml.

This allows enterprise usage of VSO to run a sidecar such as [Fluent Bit](https://fluentbit.io) and forward VSO logs to a log aggregation service. This is a requirement for me to deploy VSO for my team's services at Adobe, so I'm hoping to get this merged and released soon. Thanks!