### PR TITLE
feat: restrict with prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,9 @@ To use this in the Helm chart modify the `values.yaml` file as follows:
 ```yaml
 environmentVars:
   - name: VAULT_ALLOW_PREFIXES
-    value: common,default
+    value: "common,default"
   - name: VAULT_ALLOW_NAMESPACE_PREFIX
-    value: true
+    value: "true"
 ```
 
 This would limit the operator to only create Secrets for paths matching:

--- a/README.md
+++ b/README.md
@@ -170,6 +170,29 @@ vault:
   authMethod: approle
 ```
 
+### Client-side restriction
+
+It is possible to add client-side restrictions by matching the VaultSecret path with a list of prefixes or limit them
+to paths prefixed with the VaultSecret namespace. This is in addition to the more secure server-side Vault policies.
+
+To use this in the Helm chart modify the `values.yaml` file as follows:
+
+```yaml
+environmentVars:
+  - name: VAULT_ALLOW_PREFIXES
+    value: common,default
+  - name: VAULT_ALLOW_NAMESPACE_PREFIX
+    value: true
+```
+
+This would limit the operator to only create Secrets for paths matching:
+
+```
+secret/common/*
+secret/default/*
+secret/{VaultSecret.metadata.namespace}/*
+```
+
 ## Usage
 
 Create two Vault secrets `example-vaultsecret`:

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -47,6 +47,12 @@ environmentVars: []
   #   value: "30"
   # - name: VAULT_TOKEN_MAX_TTL
   #   value: "43200"
+  #
+  # Client-side restrictions:
+  # - name: VAULT_ALLOW_PREFIXES
+  #   value: "common,default"
+  # - name: VAULT_ALLOW_NAMESPACE_PREFIX
+  #   value: "true"
 
 # Set the address for vault (by default we assume you are running a dev
 # instance of vault in the same namespace as the operator) and specify the

--- a/controllers/vaultsecret_controller.go
+++ b/controllers/vaultsecret_controller.go
@@ -95,7 +95,15 @@ func (r *VaultSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			r.updateConditions(ctx, log, instance, conditionReasonFetchFailed, err.Error(), metav1.ConditionFalse)
 			return ctrl.Result{}, err
 		}
-		data, err = vaultClient.GetSecret(instance.Spec.SecretEngine, instance.Spec.Path, instance.Spec.Keys, instance.Spec.Version, instance.Spec.IsBinary, instance.Spec.VaultNamespace)
+		data, err = vaultClient.GetSecret(
+			instance.Spec.SecretEngine,
+			instance.Spec.Path,
+			instance.Spec.Keys,
+			instance.Spec.Version,
+			instance.Spec.IsBinary,
+			instance.Spec.VaultNamespace,
+			instance.GetObjectMeta().GetNamespace(),
+		)
 		if err != nil {
 			// Error while getting the secret from Vault - requeue the request.
 			log.Error(err, "Could not get secret from vault")
@@ -111,7 +119,16 @@ func (r *VaultSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{}, err
 		}
 
-		data, err = vault.SharedClient.GetSecret(instance.Spec.SecretEngine, instance.Spec.Path, instance.Spec.Keys, instance.Spec.Version, instance.Spec.IsBinary, instance.Spec.VaultNamespace)
+		data,
+			err = vault.SharedClient.GetSecret(
+			instance.Spec.SecretEngine,
+			instance.Spec.Path,
+			instance.Spec.Keys,
+			instance.Spec.Version,
+			instance.Spec.IsBinary,
+			instance.Spec.VaultNamespace,
+			instance.GetObjectMeta().GetNamespace(),
+		)
 		if err != nil {
 			// Error while getting the secret from Vault - requeue the request.
 			log.Error(err, "Could not get secret from vault")

--- a/vault/client.go
+++ b/vault/client.go
@@ -125,7 +125,7 @@ func (c *Client) GetSecret(
 		return nil, fmt.Errorf("vaultNamespace field can not be used, because the VAULT_NAMESPACE environment variable is not set")
 	}
 
-	// Check whether the `path` starts with an allowed prefix. This allows the
+	// Check whether the `path` matches with the allowed path. This allows the
 	// operator to add client-side restictions on top of the Vault (server-side)
 	// policies.
 	// For example:

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/hashicorp/vault/api"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -65,8 +64,7 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 	vaultSecretID := os.Getenv("VAULT_SECRET_ID")
 	vaultTokenMaxTTL := os.Getenv("VAULT_TOKEN_MAX_TTL")
 	vaultNamespace := os.Getenv("VAULT_NAMESPACE")
-	vaultAllowPrefixes := os.Getenv("VAULT_ALLOW_PREFIXES")
-	vaultAllowNamespacePrefix := os.Getenv("VAULT_ALLOW_NAMESPACE_PREFIX")
+	vaultAllowedPath := os.Getenv("VAULT_ALLOWED_PATH")
 
 	// Create new Vault configuration. This configuration is used to create the
 	// API client. We set the timeout of the HTTP client to 10 seconds.
@@ -241,9 +239,6 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 
 		apiClient.SetToken(secret.Auth.ClientToken)
 
-		allowPrefixes := strings.Split(vaultAllowPrefixes, ",")
-		allowNamespacePrefix, _ := strconv.ParseBool(vaultAllowNamespacePrefix)
-
 		return &Client{
 			client:                    apiClient,
 			tokenLeaseDuration:        tokenLeaseDuration,
@@ -251,8 +246,7 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 			tokenRenewalRetryInterval: tokenRenewalRetryInterval,
 			tokenMaxTTL:               tokenMaxTTL,
 			rootVaultNamespace:        vaultNamespace,
-			allowPrefixes:             allowPrefixes,
-			allowNamespacePrefix:      allowNamespacePrefix,
+			allowedPath:               vaultAllowedPath,
 			requestToken: func(c *Client) error {
 				secret, err := apiClient.Logical().Write(appRolePath+"/login", data)
 				if err != nil {

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/vault/api"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -64,6 +65,8 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 	vaultSecretID := os.Getenv("VAULT_SECRET_ID")
 	vaultTokenMaxTTL := os.Getenv("VAULT_TOKEN_MAX_TTL")
 	vaultNamespace := os.Getenv("VAULT_NAMESPACE")
+	vaultAllowPrefixes := os.Getenv("VAULT_ALLOW_PREFIXES")
+	vaultAllowNamespacePrefix := os.Getenv("VAULT_ALLOW_NAMESPACE_PREFIX")
 
 	// Create new Vault configuration. This configuration is used to create the
 	// API client. We set the timeout of the HTTP client to 10 seconds.
@@ -238,6 +241,9 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 
 		apiClient.SetToken(secret.Auth.ClientToken)
 
+		allowPrefixes := strings.Split(vaultAllowPrefixes, ",")
+		allowNamespacePrefix, _ := strconv.ParseBool(vaultAllowNamespacePrefix)
+
 		return &Client{
 			client:                    apiClient,
 			tokenLeaseDuration:        tokenLeaseDuration,
@@ -245,6 +251,8 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 			tokenRenewalRetryInterval: tokenRenewalRetryInterval,
 			tokenMaxTTL:               tokenMaxTTL,
 			rootVaultNamespace:        vaultNamespace,
+			allowPrefixes:             allowPrefixes,
+			allowNamespacePrefix:      allowNamespacePrefix,
 			requestToken: func(c *Client) error {
 				secret, err := apiClient.Logical().Write(appRolePath+"/login", data)
 				if err != nil {


### PR DESCRIPTION
First of all: Very nice project, great docs! Looking forward to eventually running this.

I currently have a setup using a namespaced process each with their own ServiceAccount. This allowed for a Vault policy
on the server-side similar to this:

```
path "secret/data/common/+" {
  policy = "read"
}
path "secret/data/{{identity.entity.aliases.${accessor}.metadata.service_account_namespace}}/+"{
  policy = "read"
}
```

However with this operator that kind of policy is not feasible as there is only one ServiceAccount.

This PR proposes to restrict this on the client-side side, in the operator. It check whether a `path` matches the allowed path regex.

For example:
```
c.allowedPath = '(common|{{namespace}})/.*'
```

This restricts the operator to getting secrets from:
```console
/secret/data/common
/secret/data/$secretNamespace/
```

This would mimic the behavior of original server-side policies.

~I'm also looking for feedback, the 'prefix' approach is quite simple but might not fit more advanced use cases. I'm considering changing it to a regex. wdyt?~