### PR TITLE
feat: allow Vault address to be specified in .Values.environmentVars

### DIFF
--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -52,8 +52,10 @@ spec:
             {{- else }}
               value: ""
             {{- end }}
+            {{- if .Values.vault.address }}
             - name: VAULT_ADDRESS
               value: {{ .Values.vault.address | quote }}
+            {{- end }}
             - name: VAULT_AUTH_METHOD
               value: {{ .Values.vault.authMethod | quote }}
             - name: VAULT_TOKEN_PATH

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -78,7 +78,7 @@ environmentVars: []
 # will watch all namespaces. If the value is empty and rbac.namespaced is set to
 # true, then the namespace of the release will be used.
 vault:
-  address: "http://vault:8200"
+  address: ""
   authMethod: token
   tokenPath: ""
   kubernetesPath: auth/kubernetes


### PR DESCRIPTION
This PR doesn't include `VAULT_ADDRESS` if it's not set at `.Values.vault.address`. This allows alternative ways of supplying the vault address to be used via `.Values.environmentVars`.

My use case is that `VAULT_ADDRESS` gets supplied after the helm chart has been rendered for our developer environment (think snapshots).