### PR TITLE
Add azure auth backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,19 @@ vault:
   authMethod: approle
 ```
 
+### Azure Auth Method
+
+You can use the managed system identity provided on aks cluster to authenticate against the Vault API, to do that you will need to setup an auth backend as described [here](https://www.vaultproject.io/docs/auth/azure)
+Then you can setup the auth method with the following environment variables:
+```shell
+export VAULT_AUTH_METHOD=azure
+export VAULT_AZURE_PATH=auth/azure
+export VAULT_AZURE_ROLE=default
+export VAULT_AZURE_ISSCALESET=true # Set this to true if the kubernetes nodes are in a vmss and not isolated vm (default in aks)
+```
+
+If you deploy the Vault Secrets Operator via Helm you have to set the `vault.authMethod`, `vault.azurepath`, `vault.azureRole`, `vault.azureScaleset` values in the `values.yaml` file.
+
 ## Usage
 
 Create two Vault secrets `example-vaultsecret`:

--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -68,6 +68,13 @@ spec:
               value: {{ .Values.vault.appRolePath | quote }}
             - name: VAULT_RECONCILIATION_TIME
               value: {{ .Values.vault.reconciliationTime | quote }}
+            - name: VAULT_AZURE_PATH
+              value: {{ .Values.vault.azurePath | quote }}
+            - name: VAULT_AZURE_ROLE
+              value: {{ .Values.vault.azureRole | quote }}
+            - name: VAULT_AZURE_ISSCALESET
+              value: {{ .Values.vault.azureScaleset | quote }}
+
             {{- with .Values.environmentVars }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -84,6 +84,8 @@ vault:
   kubernetesPath: auth/kubernetes
   kubernetesRole: vault-secrets-operator
   appRolePath: auth/approle
+  azurePath: auth/azure
+  azureRole: default
   reconciliationTime: 0
   namespaces: ""
 

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/vault/api"
+	"github.com/leosayous21/go-azure-msi/msi"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -60,6 +61,9 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 	vaultTokenRenewalRetryInterval := os.Getenv("VAULT_TOKEN_RENEWAL_RETRY_INTERVAL")
 	vaultKubernetesPath := os.Getenv("VAULT_KUBERNETES_PATH")
 	vaultAppRolePath := os.Getenv("VAULT_APP_ROLE_PATH")
+	vaultAzurePath := os.Getenv("VAULT_AZURE_PATH")
+	vaultAzureRole := os.Getenv("VAULT_AZURE_ROLE")
+	vaultAzureIsScaleset := os.Getenv("VAULT_AZURE_ISSCALESET")
 	vaultRoleID := os.Getenv("VAULT_ROLE_ID")
 	vaultSecretID := os.Getenv("VAULT_SECRET_ID")
 	vaultTokenMaxTTL := os.Getenv("VAULT_TOKEN_MAX_TTL")
@@ -262,5 +266,75 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 		}, nil
 	}
 
+	if vaultAuthMethod == "azure" {
+		// Check the required mount path and role for the Kubernetes Auth
+		// Method. If one of the env variable is missing we return an error.
+		if vaultAzurePath == "" {
+			vaultAzurePath = "auth/azure"
+		}
+
+		// For the shared client the Vault role must be specified via the VAULT_KUBERNETES_ROLE environment variable.
+		// If this environment variable is missing we return nil instead of an error, because the operator will work as
+		// usual, when each secret specifies the vaultRole property.
+		if vaultAzureRole == "" {
+			vaultAzureRole = "default"
+		}
+
+		// Read the service account token value and create a map for the
+		// authentication against Vault.
+		msiToken, err := msi.GetMsiToken()
+		if err != nil {
+			return nil, err
+		}
+		metadata, err := msi.GetInstanceMetadata()
+		if err != nil {
+			return nil, err
+		}
+
+		data := make(map[string]interface{})
+		data["jwt"] = string(msiToken.AccessToken)
+		data["role"] = vaultAzureRole
+		data["subscription_id"] = metadata.SubscriptionId
+		data["resource_group_name"] = metadata.ResourceGroupName
+		if vaultAzureIsScaleset {
+			data["vmss_name"] = metadata.VMssName
+		} else {
+			data["vm_name"] = metadata.VMName
+		}
+
+		// Authenticate against vault using the Azure Auth Method and set
+		// the token which the client should use for further interactions with
+		// Vault. We also set the lease duration of the token for the renew
+		// function.
+		secret, err := apiClient.Logical().Write(vaultAzurePath+"/login", data)
+		if err != nil {
+			return nil, err
+		} else if secret.Auth == nil {
+			return nil, fmt.Errorf("missing authentication information")
+		}
+
+		tokenLeaseDuration := secret.Auth.LeaseDuration
+
+		tokenRenewalInterval, err := strconv.ParseFloat(vaultTokenRenewalInterval, 64)
+		if err != nil {
+			tokenRenewalInterval = float64(tokenLeaseDuration) * 0.5
+		}
+
+		tokenRenewalRetryInterval, err := strconv.ParseFloat(vaultTokenRenewalRetryInterval, 64)
+		if err != nil {
+			tokenRenewalRetryInterval = 30.0
+		}
+
+		apiClient.SetToken(secret.Auth.ClientToken)
+
+		return &Client{
+			client:                    apiClient,
+			tokenLeaseDuration:        tokenLeaseDuration,
+			tokenRenewalInterval:      tokenRenewalInterval,
+			tokenRenewalRetryInterval: tokenRenewalRetryInterval,
+			rootVaultNamespace:        vaultNamespace,
+		}, nil
+
+	}
 	return nil, fmt.Errorf("invalid authentication method")
 }

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -296,7 +296,7 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 		data["role"] = vaultAzureRole
 		data["subscription_id"] = metadata.SubscriptionId
 		data["resource_group_name"] = metadata.ResourceGroupName
-		if vaultAzureIsScaleset {
+		if vaultAzureIsScaleset == "true" {
 			data["vmss_name"] = metadata.VMssName
 		} else {
 			data["vm_name"] = metadata.VMName


### PR DESCRIPTION
Hello !

First of all, thanks for this project ! We were having problems with argocd syncing mutated secrets with our ancient controller and this will be an amazing piece of code to run in our clusters :) 
But since we are on azure and use managed aks we also use the Managed System Identities to authenticate against the Vault API, so the aim of this PR is to be able to get this identity on aks and send the token to the vault

I've basically copy/pasted the kubernetes auth method and changed the jwt retrival with a curl to azure services.
I'm quite not sure about the name of the environment variables, I tried to keep a cohesion with what was existing

I've updated the chart and the readme accordingly but if there's anything wrong I can correct that :) 

Also this support only managed `system` identities present on azure VM and VMScaleSet [Microsoft doc](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview)

Thanks :) 
