### PR TITLE
ignore null-values from vault

### DIFF
--- a/vault/client.go
+++ b/vault/client.go
@@ -165,6 +165,9 @@ func (c *Client) GetSecret(secretEngine string, path string, keys []string, vers
 	// string, which can be used for the Kubernetes secret.
 	data := make(map[string][]byte)
 	for key, value := range secretData {
+		if value == nil {
+			continue
+		}
 		if len(keys) == 0 || contains(key, keys) {
 			switch value.(type) {
 			case map[string]interface{}:


### PR DESCRIPTION
First off, thanks for the great project!

When using vault with a secrets-engine like AWS, for example, some of the fields are null:

```
$ vault read aws/creds/route53
Key                Value
---                -----
lease_id           aws/creds/route53/xxxx
lease_duration     768h
lease_renewable    true
access_key         xxxx
secret_key         xxxxxx
security_token     <nil>

```

In 1.15 of this operator, this will cause Secret creation to fail with the message `could not parse secret value`. This PR just skips all values which are null as received from vault.