### PR TITLE
Remove created-by label

### DIFF
--- a/controllers/vaultsecret_controller.go
+++ b/controllers/vaultsecret_controller.go
@@ -286,9 +286,7 @@ func runTemplate(cr *ricobergerdev1alpha1.VaultSecret, tmpl string, secrets map[
 // newSecretForCR returns a secret with the same name/namespace as the CR. The secret will include all labels and
 // annotations from the CR.
 func newSecretForCR(cr *ricobergerdev1alpha1.VaultSecret, data map[string][]byte) (*corev1.Secret, error) {
-	labels := map[string]string{
-		"created-by": "vault-secrets-operator",
-	}
+	labels := map[string]string{}
 	for k, v := range cr.ObjectMeta.Labels {
 		labels[k] = v
 	}


### PR DESCRIPTION
This commit removes the "created-by" label, which was added to the
Kubernetes secrets created by the Vault Secrets Operator. Since this
label wasn't then used for any further actions it should be save to
remove.

If a user depends on the label for his workflows it can be added as
label to the VaultSecret and will then also be added to the Kubernetes
secret.

Closes #121.