### PR TITLE
Enable annotations to be addedd to the service account

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -25,6 +25,7 @@
 | `rbac.namespaced` | Deploy in isolated namespace. Creates RoleBinding instead of a ClusterRoleBinding | `false` |
 | `serviceAccount.create` | Create the service account. | `true` |
 | `serviceAccount.name` | The name of the service account, which should be created/used by the operator. | `vault-secrets-operator` |
+| `serviceAccount.annotations` | Annotations to be added to service account. | `{}` |
 | `podAnnotations` | Annotations for vault-secrets-operator pod(s). | `{}` |
 | `podSecurityContext`: | Security context policies to add to the operator pod. | `{}` |
 | `securityContext`: | Security context policies to add to the containers. | `{}` |

--- a/charts/vault-secrets-operator/templates/service-account.yaml
+++ b/charts/vault-secrets-operator/templates/service-account.yaml
@@ -6,4 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "vault-secrets-operator.labels" . | indent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{ end }}


### PR DESCRIPTION
Allow for annotations on the service account to be defined using variables.

Doing so allows for multiple use case primary concern here is to allow for Workload Identity use cases.