### PR TITLE
Allow token renewal to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To use Token auth method for the authentication against the Vault API, you need 
 vault token create -period=24h -policy=vault-secrets-operator
 ```
 
-To use the created token you need to pass the token as an environment variable to the operator. For security reasons the operator only supports the passing of environment variables via a Kubernetes secret. The secret with the keys `VAULT_TOKEN` and `VAULT_TOKEN_LEASE_DURATION` (as well as optional keys `VAULT_TOKEN_RENEWAL_INTERVAL` and `VAULT_TOKEN_RENEWAL_RETRY_INTERVAL` to control timings for token renewals, if required) can be created with the following command:
+To use the created token you need to pass the token as an environment variable to the operator. For security reasons the operator only supports the passing of environment variables via a Kubernetes secret. The secret with the keys `VAULT_TOKEN` and `VAULT_TOKEN_LEASE_DURATION` (as well as optional keys `VAULT_TOKEN_RENEWAL_INTERVAL` and `VAULT_TOKEN_RENEWAL_RETRY_INTERVAL` to control timings for token renewals, if required. `VAULT_RENEW_TOKEN` can also be set to `"false"` to disable the operators token renew loop) can be created with the following command:
 
 ```sh
 export VAULT_TOKEN=

--- a/main.go
+++ b/main.go
@@ -57,7 +57,9 @@ func main() {
 		os.Exit(1)
 	} else {
 		if vault.SharedClient != nil {
-			go vault.SharedClient.RenewToken()
+			if vault.SharedClient.PerformRenewToken() {
+				go vault.SharedClient.RenewToken()
+			}
 		} else {
 			ctrl.Log.Info("Shared client wasn't initialized, each secret must be use the vaultRole property")
 		}

--- a/vault/client.go
+++ b/vault/client.go
@@ -22,6 +22,10 @@ type Client struct {
 	client *api.Client
 	// tokenLeaseDuration is the lease duration of the token for the interaction with vault.
 	tokenLeaseDuration int
+	// renewToken is whether the operator should renew its own token
+	// to be used when a service external to the operator renews the token itself
+	// defaults to true 
+	renewToken bool
 	// tokenRenewalInterval is the time between two successive vault token renewals.
 	tokenRenewalInterval float64
 	// tokenRenewalRetryInterval is the time until a failed vault token renewal is retried.
@@ -36,6 +40,11 @@ type Client struct {
 	// failedRenewTokenAttempts is the number of failed renew token attempts, if the renew token function fails 5 times
 	// the liveness probe will fail, to force a restart of the operator.
 	failedRenewTokenAttempts int
+}
+
+// PerformRenewToken returns whether the operator should renew its token
+func (c *Client) PerformRenewToken() bool {
+	return c.renewToken
 }
 
 // RenewToken renews the provided token after the half of the lease duration is

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -57,6 +57,7 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 	vaultToken := os.Getenv("VAULT_TOKEN")
 	vaultTokenPath := os.Getenv("VAULT_TOKEN_PATH")
 	vaultTokenLeaseDuration := os.Getenv("VAULT_TOKEN_LEASE_DURATION")
+	vaultRenewToken := os.Getenv("VAULT_RENEW_TOKEN")
 	vaultTokenRenewalInterval := os.Getenv("VAULT_TOKEN_RENEWAL_INTERVAL")
 	vaultTokenRenewalRetryInterval := os.Getenv("VAULT_TOKEN_RENEWAL_RETRY_INTERVAL")
 	vaultKubernetesPath := os.Getenv("VAULT_KUBERNETES_PATH")
@@ -111,6 +112,11 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 			return nil, err
 		}
 
+		renewToken, err := strconv.ParseBool(vaultRenewToken)
+		if err == nil {
+			renewToken = true
+		}
+
 		tokenRenewalInterval, err := strconv.ParseFloat(vaultTokenRenewalInterval, 64)
 		if err != nil {
 			tokenRenewalInterval = float64(tokenLeaseDuration) * 0.5
@@ -126,6 +132,7 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 
 		return &Client{
 			client:                    apiClient,
+			renewToken:                renewToken,
 			tokenLeaseDuration:        tokenLeaseDuration,
 			tokenRenewalInterval:      tokenRenewalInterval,
 			tokenRenewalRetryInterval: tokenRenewalRetryInterval,


### PR DESCRIPTION
In kubernetes when using `auto-auth` with the `vault-agent-injector` the injector will renew the token on behalf of the service that requested it. Adding the ability to disable the operator from renewing the token so that there is less API calls into Vault. 

The default behavior is unchanged. This option must be enabled to occur. 