### PR TITLE
Set issuer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,10 +12,6 @@ insert_final_newline = true
 indent_style = tab
 indent_size = 4
 
-[*.md]
-indent_style = tab
-indent_size = 4
-
 [Makefile]
 indent_style = tab
 indent_size = 4

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ vault auth enable kubernetes
 
 # Tell Vault how to communicate with the Kubernetes cluster
 vault write auth/kubernetes/config \
+  issuer="https://kubernetes.default.svc.cluster.local" \
   token_reviewer_jwt="$SA_JWT_TOKEN" \
   kubernetes_host="$K8S_HOST" \
   kubernetes_ca_cert="$SA_CA_CRT"
@@ -123,6 +124,7 @@ vault write auth/kubernetes/role/vault-secrets-operator \
 # If you're running Vault inside kubernetes, you can alternatively exec into any Vault pod and run this...
 # In some bare-metal k8s setups this method is necessary.
 # vault write auth/kubernetes/config \
+#   issuer="https://kubernetes.default.svc.cluster.local" \
 #   token_reviewer_jwt="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
 #   kubernetes_host=https://${KUBERNETES_PORT_443_TCP_ADDR}:443 \
 #   kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt

--- a/testbin/setup-kind-kubernetes-namespaced.sh
+++ b/testbin/setup-kind-kubernetes-namespaced.sh
@@ -78,7 +78,7 @@ export SA_CA_CRT=$(kubectl get secret --namespace=vault-secrets-operator $VAULT_
 export K8S_HOST=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
 env | grep -E 'VAULT_SECRETS_OPERATOR_NAMESPACE|VAULT_SECRET_NAME|SA_JWT_TOKEN|SA_CA_CRT|K8S_HOST'
 vault auth enable kubernetes
-vault write auth/kubernetes/config token_reviewer_jwt="$SA_JWT_TOKEN" kubernetes_host="https://kubernetes.default.svc" kubernetes_ca_cert="$SA_CA_CRT" disable_iss_validation=true
+vault write auth/kubernetes/config token_reviewer_jwt="$SA_JWT_TOKEN" kubernetes_host="https://kubernetes.default.svc" kubernetes_ca_cert="$SA_CA_CRT" issuer="https://kubernetes.default.svc.cluster.local"
 vault write auth/kubernetes/role/vault-secrets-operator bound_service_account_names="vault-secrets-operator" bound_service_account_namespaces="$VAULT_SECRETS_OPERATOR_NAMESPACE" policies=vault-secrets-operator ttl=24h
 
 cat <<EOF | kubectl apply -f -

--- a/testbin/setup-kind-kubernetes-nosharedclient.sh
+++ b/testbin/setup-kind-kubernetes-nosharedclient.sh
@@ -78,7 +78,7 @@ export SA_CA_CRT=$(kubectl get secret --namespace=vault-secrets-operator $VAULT_
 export K8S_HOST=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
 env | grep -E 'VAULT_SECRETS_OPERATOR_NAMESPACE|VAULT_SECRET_NAME|SA_JWT_TOKEN|SA_CA_CRT|K8S_HOST'
 vault auth enable kubernetes
-vault write auth/kubernetes/config token_reviewer_jwt="$SA_JWT_TOKEN" kubernetes_host="https://kubernetes.default.svc" kubernetes_ca_cert="$SA_CA_CRT" disable_iss_validation=true
+vault write auth/kubernetes/config token_reviewer_jwt="$SA_JWT_TOKEN" kubernetes_host="https://kubernetes.default.svc" kubernetes_ca_cert="$SA_CA_CRT" issuer="https://kubernetes.default.svc.cluster.local"
 vault write auth/kubernetes/role/vault-secrets-operator bound_service_account_names="vault-secrets-operator" bound_service_account_namespaces="$VAULT_SECRETS_OPERATOR_NAMESPACE" policies=vault-secrets-operator ttl=24h
 
 cat <<EOF | kubectl apply -f -

--- a/testbin/setup-kind-kubernetes-sharedclient.sh
+++ b/testbin/setup-kind-kubernetes-sharedclient.sh
@@ -78,7 +78,7 @@ export SA_CA_CRT=$(kubectl get secret --namespace=vault-secrets-operator $VAULT_
 export K8S_HOST=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
 env | grep -E 'VAULT_SECRETS_OPERATOR_NAMESPACE|VAULT_SECRET_NAME|SA_JWT_TOKEN|SA_CA_CRT|K8S_HOST'
 vault auth enable kubernetes
-vault write auth/kubernetes/config token_reviewer_jwt="$SA_JWT_TOKEN" kubernetes_host="https://kubernetes.default.svc" kubernetes_ca_cert="$SA_CA_CRT" disable_iss_validation=true
+vault write auth/kubernetes/config token_reviewer_jwt="$SA_JWT_TOKEN" kubernetes_host="https://kubernetes.default.svc" kubernetes_ca_cert="$SA_CA_CRT" issuer="https://kubernetes.default.svc.cluster.local"
 vault write auth/kubernetes/role/vault-secrets-operator bound_service_account_names="vault-secrets-operator" bound_service_account_namespaces="$VAULT_SECRETS_OPERATOR_NAMESPACE" policies=vault-secrets-operator ttl=24h
 
 cat <<EOF | kubectl apply -f -


### PR DESCRIPTION
To fix the `claim "iss" is invalid` error for Kubernetes 1.21.x and newer we have to set the issuer, while configuring the Kubernetes auth method.

Closes #104 