### PR TITLE
Add args as value for Helm chart

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -11,6 +11,7 @@
 | `imagePullSecrets` | Secrets which can be used to pull the Docker image. | `[]` |
 | `nameOverride` | Expand the name of the chart. | `""` |
 | `fullnameOverride` | Override the name of the app. | `""` |
+| `args` | Set the arguments for the operator. | `["-leader-elect"]` |
 | `environmentVars` | Pass environment variables from a secret to the containers. This must be used if you use the Token auth method of Vault. | `[]` |
 | `vault.address` | The address where Vault listen on (e.g. `http://vault.example.com`). | `"http://vault:8200"` |
 | `vault.authMethod` | The authentication method, which should be used by the operator. Can by `token` ([Token auth method](https://www.vaultproject.io/docs/auth/token.html)), `aws` ([AWS auth method](https://www.vaultproject.io/docs/auth/aws)), `gcp` ([GCP auth method](https://www.vaultproject.io/docs/auth/gcp)), `kubernetes` ([Kubernetes auth method](https://www.vaultproject.io/docs/auth/kubernetes.html)), or `approle` ([AppRole auth method](https://www.vaultproject.io/docs/auth/approle)). | `token` |

--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -42,8 +42,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /manager
+          {{- with .Values.args }}
           args:
-            - -leader-elect
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: WATCH_NAMESPACE
             {{- if .Values.vault.namespaces }}

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -13,6 +13,9 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+args:
+  - -leader-elect
+
 environmentVars: []
   # Set environment variables from a secret. This must be done, if you use the
   # Token or AppRole Auth Methods of Vault.


### PR DESCRIPTION
It is now possible to set the arguments for the operator container via
the Helm chart. By default we are setting the "-leader-elect" argument
to enable leader election for the Vault Secrets Operator.