### PR TITLE
Split configmaps and leases in different entries on vault-secret-operator role

### DIFF
--- a/charts/vault-secrets-operator/templates/role.yaml
+++ b/charts/vault-secrets-operator/templates/role.yaml
@@ -8,10 +8,20 @@ metadata:
 {{ include "vault-secrets-operator.labels" . | indent 4 }}
 rules:
 - apiGroups:
-  - coordination.k8s.io
   - ""
   resources:
   - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
   - leases
   verbs:
   - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,10 +7,20 @@ metadata:
   name: vault-secrets-operator
 rules:
 - apiGroups:
-  - coordination.k8s.io
   - ""
   resources:
-  - configmaps
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
   - leases
   verbs:
   - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,7 +9,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - leases
+  - configmaps
   verbs:
   - create
   - delete


### PR DESCRIPTION
Fixes #136 
Changes done:
- Split configmaps and leases in different entries on vault-secret-operator role