### PR TITLE
fix: renew token is only set when parsed

### DIFF
--- a/vault/vault.go
+++ b/vault/vault.go
@@ -107,7 +107,7 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 	}
 
 	renewToken, err := strconv.ParseBool(vaultRenewToken)
-	if err == nil {
+	if err != nil {
 		renewToken = true
 	}
 


### PR DESCRIPTION
and then only to true. By default no renewal will happen, you need to set `VAULT_RENEW_TOKEN` to any value to get token renewal.