### PR TITLE
Add namespace to test-connection pod

### DIFF
--- a/charts/vault-secrets-operator/templates/tests/test-connection.yaml
+++ b/charts/vault-secrets-operator/templates/tests/test-connection.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "vault-secrets-operator.fullname" . }}-test-connection"
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "vault-secrets-operator.labels" . | indent 4 }}
 {{ include "vault-secrets-operator.testPodLabels" . | indent 4 }}


### PR DESCRIPTION
If you deploy the operator not to the default namespace, you will get connection error in test-connection pod. My commit fixes this