### PR TITLE
Update docs for reconciliation time

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ metadata:
 type: Opaque
 ```
 
-The `spec.type` and `spec.keys` fields are handled in the same way for both versions of the KV secret engine. The `spec.version` field is only processed, when the secret is saved under a KVv2 secret engine. If you specified the `VAULT_RECONCILIATION_TIME` environment variable with a value greater than `0` every secret is reconciled after the given time. This means, when you do not specify `spec.version`, the Kubernetes secret will be automatically updated if the Vault secret changes.
+The `spec.type` and `spec.keys` fields are handled in the same way for both versions of the KV secret engine. The `spec.version` field is only processed, when the secret is saved under a KVv2 secret engine. If you specified the `VAULT_RECONCILIATION_TIME` environment variable with a value greater than `0` every secret is reconciled after the given time (in seconds). This means, when you do not specify `spec.version`, the Kubernetes secret will be automatically updated if the Vault secret changes. To set the `VAULT_RECONCILIATION_TIME` environment variable in the Helm chart the `vault.reconciliationTime` value can be used.
 
 The binary data stored in vault requires [base64 encoding](https://github.com/hashicorp/vault/issues/1423#issuecomment-219525845). the
 `spec.isBinary` can be used to prevent such data get base64 encoded again when store as secret in k8s.


### PR DESCRIPTION
From the current documentation it wasn't clear that the `VAULT_RECONCILIATION_TIME` environment variable specifies the reconciliation time in seconds and that the corresponding value in the Helm chart is `vault.reconciliationTime`. This should be fixed now.

Closes #147 