### PR TITLE
feat: add network policy

### DIFF
--- a/charts/vault-secrets-operator/templates/network-policy.yaml
+++ b/charts/vault-secrets-operator/templates/network-policy.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ include "vault-secrets-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "vault-secrets-operator.labels" . | indent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+{{ include "vault-secrets-operator.matchLabels" . | indent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    {{- if .Values.serviceMonitor.enabled }}
+    # Allow prometheus scrapes
+    - ports:
+        - port: 8080
+    {{- end }}
+  egress:
+    # Allow DNS resolution
+    - ports:
+        - port: 53
+          protocol: TCP
+        - port: 53
+          protocol: UDP
+    {{- if .Values.networkPolicy.egress }}
+    {{ toYaml .Values.networkPolicy.egress | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -168,6 +168,16 @@ serviceMonitor:
 # A priority class can be optionally attached to the pod spec if one is needed
 # priorityClassName: high
 
+networkPolicy:
+  enabled: false
+  egress: []
+    # - to:
+    #     - ipBlock:
+    #       cidr: 10.0.0.0/24
+    #   ports:
+    #     - port: 443
+    #       protocol: TCP
+
 tests:
   # imagePullSecrets:
   # - imagePullSecret


### PR DESCRIPTION
Considering the sensitive nature of the data passing through the controller I thought the ability to restrict egress would be welcomed.

If I understand it correctly the controller only needs access to the DNS resolver and vault itself, but the template allows a flexible egress configuration.

I wasn't sure how to reflect the change in the chart's version since it seems to be tied to the application's version.

Please let me know if further changes are required.