### PR TITLE
Add support for configuring the vault.namespaces value as a list

### DIFF
--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -49,7 +49,11 @@ spec:
           env:
             - name: WATCH_NAMESPACE
             {{- if .Values.vault.namespaces }}
+              {{- if kindIs "slice" .Values.vault.namespaces }}
+              value: {{ .Values.vault.namespaces | join "," | quote }}
+              {{- else }}
               value: {{ .Values.vault.namespaces | quote }}
+              {{- end -}}
             {{- else if .Values.rbac.namespaced }}
               value: {{ .Release.Namespace | quote }}
             {{- else }}


### PR DESCRIPTION
At Adobe, for our specific use case we would like to be able to use the same list of Kubernetes namespaces for configuring both the Vault Secrets Operator and also a whole other bunch of operators that need to watch over the same namespaces.

This PR makes it possible to pass the `vault.namespaces` key both as a comma-separated list of namespaces (a string) as well as a conventional YAML list.

Current behaviour is not affected by this change. In consequence, here is what templating will result based on the value/format of the `vault.namespaces` key:

| Value                                                                      	| Templated `deployment.yaml`                                                              	|
|----------------------------------------------------------------------------	|------------------------------------------------------------------------------------------	|
| <pre><br>vault:<br>  namespaces: ""<br></pre>                              	| <pre><br>...<br>- name: WATCH_NAMESPACE<br>  value: ""<br>...<br></pre>                  	|
| <pre><br>vault:<br>  namespaces: []<br></pre>                              	| <pre><br>...<br>- name: WATCH_NAMESPACE<br>  value: ""<br>...<br></pre>                  	|
| <pre><br>vault:<br>  namespaces: "test-ns1,test-ns2"<br></pre>             	| <pre><br>...<br>- name: WATCH_NAMESPACE<br>  value: "test-ns1,test-ns2"<br>...<br></pre> 	|
| <pre><br>vault:<br>  namespaces: [test-ns1, test-ns2]<br></pre>            	| <pre><br>...<br>- name: WATCH_NAMESPACE<br>  value: "test-ns1,test-ns2"<br>...<br></pre> 	|
| <pre><br>vault:<br>  namespaces:<br>  - test-ns1<br>  - test-ns2<br></pre> 	| <pre><br>...<br>- name: WATCH_NAMESPACE<br>  value: "test-ns1,test-ns2"<br>...<br></pre> 	|