### PR TITLE
Add custom metric for reconciliation failures

### DIFF
--- a/controllers/metrics/metrics.go
+++ b/controllers/metrics/metrics.go
@@ -1,0 +1,21 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	VaultSecretsReconciliationsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "vaultsecrets_reconciliations_total",
+			Help: "Total number of reconciliations",
+		},
+		[]string{"namespace", "name", "status"},
+	)
+)
+
+func init() {
+	// Register custom metrics with the global prometheus registry
+	metrics.Registry.MustRegister(VaultSecretsReconciliationsTotal)
+}


### PR DESCRIPTION
Add a new custom metric `vaultsecrets_reconciliations_total` with a `namespace`, `name` and `status` label to monitor reconciliation failures per VaultSecret.

If the `status` label is `True` the reconciliation was successful, if it is `False` the reconciliation failed.