### PR TITLE
Add vaultsecrets_reconciliation_status Metric

### DIFF
--- a/controllers/metrics/metrics.go
+++ b/controllers/metrics/metrics.go
@@ -13,9 +13,17 @@ var (
 		},
 		[]string{"namespace", "name", "status"},
 	)
+	VaultSecretsReconciliationStatus = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "vaultsecrets_reconciliation_status",
+			Help: "Reconciliation status (0 = failed and 1 = ok)",
+		},
+		[]string{"namespace", "name"},
+	)
 )
 
 func init() {
 	// Register custom metrics with the global prometheus registry
 	metrics.Registry.MustRegister(VaultSecretsReconciliationsTotal)
+	metrics.Registry.MustRegister(VaultSecretsReconciliationStatus)
 }

--- a/controllers/vaultsecret_controller.go
+++ b/controllers/vaultsecret_controller.go
@@ -217,6 +217,11 @@ func (r *VaultSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 func (r *VaultSecretReconciler) updateConditions(ctx context.Context, instance *ricobergerdev1alpha1.VaultSecret, reason, message string, status metav1.ConditionStatus) {
 	metrics.VaultSecretsReconciliationsTotal.WithLabelValues(instance.Namespace, instance.Name, string(status)).Inc()
+	if status == metav1.ConditionTrue {
+		metrics.VaultSecretsReconciliationStatus.WithLabelValues(instance.Namespace, instance.Name).Set(1)
+	} else {
+		metrics.VaultSecretsReconciliationStatus.WithLabelValues(instance.Namespace, instance.Name).Set(0)
+	}
 
 	instance.Status.Conditions = []metav1.Condition{{
 		Type:               conditionTypeSecretCreated,


### PR DESCRIPTION
The new "vaultsecrets_reconciliation_status" can be used to monitor the status of a single VaultSecret. If the metric is 1 the reconciliation of a secret was successfull. If the metric is 0 the reconciliation of a secret failed.