### PR TITLE
Support initContainers

### DIFF
--- a/charts/vault-secrets-operator/Chart.yaml
+++ b/charts/vault-secrets-operator/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: Rico Berger
     url: https://ricoberger.de
 name: vault-secrets-operator
-version: 2.0.1
+version: 2.1.0

--- a/charts/vault-secrets-operator/templates/_helpers.tpl
+++ b/charts/vault-secrets-operator/templates/_helpers.tpl
@@ -97,6 +97,18 @@ Additional containers to add to the deployment
 {{- end -}}
 
 {{/*
+initContainers to add to the deployment. Example:
+- name: my-init-container
+  image: busy-box
+  command:
+    - sh
+    - -c
+    - my-command; my-other-command
+*/}}
+{{- define "vault-secrets-operator.initContainers" -}}
+{{- end -}}
+
+{{/*
 Helper function for checking if a property is defined
 */}}
 {{- define "vault-secrets-operator.imageRef" -}}

--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
       serviceAccountName: {{ template "vault-secrets-operator.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.includeInitContainers }}
+      initContainers:
+      {{- include "vault-secrets-operator.initContainers" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -122,6 +122,9 @@ testPodAnnotations: {}
 # Additional labels for the vault-secrets-operator-test-connection pod
 testPodLabels: {}
 
+# Whether to include the 'vault-secrets-operator.initContainers' template in the deployment template spec
+includeInitContainers: false
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
This adds backwards-compatible support for injecting arbitrary initContainers as a template. Turning on `.Values.includeInitContainers` will cause the `vault-secrets-operator.initContainers` template to be injected into the deployment template spec. I included sample usage in the comment where the `vault-secrets-operator.initContainers` template is defined. Using that sample and turning on `.Values.includeInitContainers` injects the `initContainers` as follows:
 
<img width="1070" alt="image" src="https://user-images.githubusercontent.com/5944767/216170570-91122713-a9c1-4eea-9d29-45ad6df438ee.png">
