### PR TITLE
Add support to auto requeue secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,23 @@ secrets:
   baz: "bazvalue
 ```
 
+**Auto Requesting Secret**
+The request is going to be based on `autoRequest` parmaters (*optional*). Default value is set to `false` which means that secret is going ot be populated from `Vault` and that's it, to updated it, you need force re-sync. If value would be set as true, then operator, will be constantly requesting the secret value from `Vault`. 
+
+```yaml
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: kvv1-example-vaultsecret
+spec:
+  keys:
+    - foo
+  isBinary: true
+  path: kvv1/example-vaultsecret
+  type: Opaque
+  autoRequest: true
+```
+
 #### Notes on templating
 
 * All secrets data is converted to string before being passed to the templating engine, so using binary data will not work well, or at least be unpredictable.
@@ -628,6 +645,8 @@ spec:
 ```
 
 The Vault Namespace, which is used to get the secret in the above example will be `my/root/ns/team1`.
+
+####
 
 ### Propagating labels
 

--- a/api/v1alpha1/vaultsecret_types.go
+++ b/api/v1alpha1/vaultsecret_types.go
@@ -56,6 +56,10 @@ type VaultSecretSpec struct {
 	// get double encoded. This flag will skip the base64 encode which is needed
 	// for string data to avoid the double encode problem.
 	IsBinary bool `json:"isBinary,omitempty"`
+	// autoRequest is a flag that indicates to keep requesing secret
+	// continiously from Vault to automatically fetch secret if new version
+	// was publised.
+	AutoRequest bool `json:"autoRequest,omitempty"`
 }
 
 // VaultSecretStatus defines the observed state of VaultSecret

--- a/config/crd/bases/ricoberger.de_vaultsecrets.yaml
+++ b/config/crd/bases/ricoberger.de_vaultsecrets.yaml
@@ -56,6 +56,11 @@ spec:
           spec:
             description: VaultSecretSpec defines the desired state of VaultSecret
             properties:
+              autoRequest:
+                description: autoRequest is a flag that indicates to keep requesing
+                  secret continiously from Vault to automatically fetch secret if
+                  new version was publised.
+                type: boolean
               engineOptions:
                 additionalProperties:
                   type: string

--- a/controllers/vaultsecret_controller.go
+++ b/controllers/vaultsecret_controller.go
@@ -211,6 +211,12 @@ func (r *VaultSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		r.updateConditions(ctx, instance, conditionReasonUpdated, "Secret was updated", metav1.ConditionTrue)
 	}
 
+	// Set auto reconcile based on spec.autoRequest field; false if not set
+	// Default ctrl.Result{} is Requeue = false
+	if !reconcileResult.Requeue {
+		reconcileResult.Requeue = instance.Spec.AutoRequest
+	}
+
 	// Secret updated successfully - requeue only if no version is specified
 	return reconcileResult, nil
 }


### PR DESCRIPTION
This PR updates CRD to have additional field to autoRequest (bool) secrets from Vault 

### Problem statement
If you deploy secrets with VaultSecret CR and then update version of secret in Vault then secret won't be automatically updated. To apply secret you need to force apply changes (In ArgoCD force sync-up)
Tested with:
- Local apply
- ArgoCD

### Changes
- Add new optional CRD field -> autoRequest
- Controller sets ctrl.Result{Requeue: true} if it is not overwritten as set in VaultSecret manifest. If value is not set nil value performed as false for bool
- Update docs in examples how to use it

### Comments
This small bug lil bit ruins auto GitOps approach and keep relying on human that they will force update CR/Secret. Also would be really valuable and convenient if people are having auto-rotation scripts
