### PR TITLE
Support dnsConfig and dnsPolicy in pod and test pod specs

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -52,3 +52,5 @@
 | `serviceMonitor.honorLabels` | Honor labels option. | `true` |
 | `serviceMonitor.relabelings` | Additional relabeling config for the ServiceMonitor. | `[]` |
 | `priorityClassName` | Optionally attach priority class to pod spec. | `null` |
+| `dnsConfig` | Optionally attach dnsConfig to pod spec and test pod spec. | `null` |
+| `dnsPolicy` | Optionally specify the dnsPolicy in pod spec and test pod spec. | `null` |

--- a/charts/vault-secrets-operator/Chart.yaml
+++ b/charts/vault-secrets-operator/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: Rico Berger
     url: https://ricoberger.de
 name: vault-secrets-operator
-version: 2.2.0
+version: 2.3.0

--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -27,6 +27,13 @@ spec:
 {{ include "vault-secrets-operator.annotations" . | indent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -148,7 +155,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.topologySpreadConstraints }}
-      topologySpreadConstraints: 
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.priorityClassName }}

--- a/charts/vault-secrets-operator/templates/tests/test-connection.yaml
+++ b/charts/vault-secrets-operator/templates/tests/test-connection.yaml
@@ -10,6 +10,13 @@ metadata:
     "helm.sh/hook": test-success
 {{ include "vault-secrets-operator.testPodAnnotations" . | indent 4 }}
 spec:
+  {{- with .Values.dnsConfig }}
+  dnsConfig:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.dnsPolicy }}
+  dnsPolicy: {{ . }}
+  {{- end }}
   {{- with .Values.tests.imagePullSecrets }}
   imagePullSecrets:
   {{- toYaml . | nindent 4 }}

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -174,6 +174,15 @@ serviceMonitor:
 # A priority class can be optionally attached to the pod spec if one is needed
 # priorityClassName: high
 
+# A dnsConfig can be optionally attached to the pod spec and test pod spec if one is needed
+#dnsConfig:
+#  nameservers: []
+#  searches: []
+#  options: []
+
+# A dnsPolicy can be optionally attached to the pod spec and test pod spec if one is needed
+# dnsPolicy: None
+
 networkPolicy:
   enabled: false
   egress: []


### PR DESCRIPTION
This PR adds support for specifying a custom DNS configuration and policy for the VSO pods and the test pod. Specifying `dnsConfig` and/or `dnsPolicy` adds the item to the spec as follows:

<img width="1078" alt="dnsConfig" src="https://user-images.githubusercontent.com/5944767/233147228-6681c66f-361d-4edc-82f0-772cf4302010.png">

This allows for consumers to use a custom DNS resolver, for example `dnsmasq`, which can reduce load on the `coreDNS` implementation and in turn reduce load on the kube-api. 