### PR TITLE
Create Secret for Service Account

### DIFF
--- a/charts/vault-secrets-operator/templates/secret.yaml
+++ b/charts/vault-secrets-operator/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.createSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "vault-secrets-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "vault-secrets-operator.labels" . | indent 4 }}
+  annotations:
+    kubernetes.io/service-account.name: {{ template "vault-secrets-operator.serviceAccountName" . }}
+type: kubernetes.io/service-account-token
+{{- end }}

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -105,6 +105,7 @@ rbac:
 serviceAccount:
   create: true
   name: vault-secrets-operator
+  createSecret: true
 
 # Annotations for vault-secrets-operator pod(s).
 podAnnotations: {}


### PR DESCRIPTION
In Kubernetes 1.24 service account tokens are no longer autogenerated for every ServiceAccount, so that we have to create the secret in the Helm chart.