### PR TITLE
fix foreground cascading deletion failed issue

### DIFF
--- a/controllers/vaultsecret_controller.go
+++ b/controllers/vaultsecret_controller.go
@@ -86,6 +86,13 @@ func (r *VaultSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
+	// Check if the VaultSecret instance is marked to be deleted, which is
+    // indicated by the deletion timestamp being set. The object will be deleted.
+    isVaultSecretMarkedToBeDeleted := instance.GetDeletionTimestamp() != nil
+    if isVaultSecretMarkedToBeDeleted {
+        return ctrl.Result{}, nil
+    }
+
 	// Get secret from Vault.
 	// If the VaultSecret contains the vaulRole property we are creating a new client with the specified Vault Role to
 	// get the secret.


### PR DESCRIPTION
This PR fixes #197 foreground cascading deletion failed issue.

Modify to do nothing if the VaultSecret instance is marked to be deleted, so that the VaultSecret is just waiting to be removed by K8S GC. 

After test again using kubectl to delete VaultSecret via foreground cascading deletion, the vault-secrets-operator does not throw any more errors.

```bash
kubectl delete vaultsecret/helloworld --cascade='foreground'
```

Closes #197 