### PR TITLE
feat: vault client can read a different service account token path

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -16,7 +16,7 @@
 | `environmentVars` | Pass environment variables from a secret to the containers. This must be used if you use the Token auth method of Vault. | `[]` |
 | `vault.address` | The address where Vault listen on (e.g. `http://vault.example.com`). | `"http://vault:8200"` |
 | `vault.authMethod` | The authentication method, which should be used by the operator. Can by `token` ([Token auth method](https://www.vaultproject.io/docs/auth/token.html)), `aws` ([AWS auth method](https://www.vaultproject.io/docs/auth/aws)), `gcp` ([GCP auth method](https://www.vaultproject.io/docs/auth/gcp)), `kubernetes` ([Kubernetes auth method](https://www.vaultproject.io/docs/auth/kubernetes.html)), or `approle` ([AppRole auth method](https://www.vaultproject.io/docs/auth/approle)). | `token` |
-| `vault.tokenPath` | Path to file with the Vault token if the used auth method is `token`. Can be used to read the token from a file and not from the  `VAULT_TOKEN` environment variable. | `""` |
+| `vault.tokenPath` | Path to file with the Vault token if the used auth method is `token`. Can be used to read the token from a file and not from the  `VAULT_TOKEN` environment variable. If the used auth method `kubernetes` you path to file the service account token path. | `""` |
 | `vault.kubernetesPath` | If the Kubernetes auth method is used, this is the path where the Kubernetes auth method is enabled. | `auth/kubernetes` |
 | `vault.kubernetesRole` | The name of the role which is configured for the Kubernetes auth method. | `vault-secrets-operator` |
 | `vault.awsPath` | If the AWS auth method is used, this is the path where the AWS auth method is enabled. | `auth/aws` |

--- a/charts/README.md
+++ b/charts/README.md
@@ -16,7 +16,7 @@
 | `environmentVars` | Pass environment variables from a secret to the containers. This must be used if you use the Token auth method of Vault. | `[]` |
 | `vault.address` | The address where Vault listen on (e.g. `http://vault.example.com`). | `"http://vault:8200"` |
 | `vault.authMethod` | The authentication method, which should be used by the operator. Can by `token` ([Token auth method](https://www.vaultproject.io/docs/auth/token.html)), `aws` ([AWS auth method](https://www.vaultproject.io/docs/auth/aws)), `gcp` ([GCP auth method](https://www.vaultproject.io/docs/auth/gcp)), `kubernetes` ([Kubernetes auth method](https://www.vaultproject.io/docs/auth/kubernetes.html)), or `approle` ([AppRole auth method](https://www.vaultproject.io/docs/auth/approle)). | `token` |
-| `vault.tokenPath` | Path to file with the Vault token if the used auth method is `token`. Can be used to read the token from a file and not from the  `VAULT_TOKEN` environment variable. If the used auth method `kubernetes` you path to file the service account token path. | `""` |
+| `vault.tokenPath` | Path to file with the Vault token if the used auth method is `token`. Can be used to read the token from a file and not from the  `VAULT_TOKEN` environment variable. If the used auth method `kubernetes` the file path of service account will set. | `""` |
 | `vault.kubernetesPath` | If the Kubernetes auth method is used, this is the path where the Kubernetes auth method is enabled. | `auth/kubernetes` |
 | `vault.kubernetesRole` | The name of the role which is configured for the Kubernetes auth method. | `vault-secrets-operator` |
 | `vault.awsPath` | If the AWS auth method is used, this is the path where the AWS auth method is enabled. | `auth/aws` |

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -193,9 +193,15 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 			return nil, nil
 		}
 
+		serviceAccountTokenPath := "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+		if vaultTokenPath != "" {
+			serviceAccountTokenPath = vaultTokenPath
+		}
+
 		// Read the service account token value and create a map for the
 		// authentication against Vault.
-		kubeToken, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+		kubeToken, err := ioutil.ReadFile(serviceAccountTokenPath)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR allows to read a different service account token that can have permissions to auth with vault for getting vault token, but it doesn't have permissions to create a secret in the Kubernetes cluster.

---

#### Key Changes:

1. *Token Path Flexibility*: Implementation of functionality that allows the Vault client to read service account tokens from customized paths.
2. *Documentation Update*: Modifications in `charts/README.md` to explain how to set up this new option.
3. *Code Adjustments*: Update in `vault/vault.go` to support this flexibility in the token path.

---

#### Benefits:

- Improved security through the use of tokens with specific permissions.
- Increased versatility in the configuration of authentication with Vault.