### PR TITLE
Restrict Operator to Vault Namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ EOF
 ```
 
 To access Vault, the operator can choose between:
-- **[Token Auth Method](https://www.vaultproject.io/docs/auth/token.html)** 
-- **[Kubernetes Auth Method](https://www.vaultproject.io/docs/auth/kubernetes.html)** 
+- **[Token Auth Method](https://www.vaultproject.io/docs/auth/token.html)**
+- **[Kubernetes Auth Method](https://www.vaultproject.io/docs/auth/kubernetes.html)**
 - **[AppRole Auth Method](https://www.vaultproject.io/docs/auth/approle.html)**
 - **[Username & Password Auth Method](https://www.vaultproject.io/docs/auth/userpass.html)**
 - **[AWS Auth Method](https://www.vaultproject.io/docs/auth/aws.html)**
@@ -669,6 +669,8 @@ spec:
 ```
 
 The Vault Namespace, which is used to get the secret in the above example will be `my/root/ns/team1`.
+
+The operator can also be restricted to only reconcile secrets where the `spec.vaultNamespace` field is the same as the `VAULT_NAMESPACE` environment variable. For this the `VAULT_RESTRICT_NAMESPACE` environment variable must be set to `true`. When this feature is enabled the operator can not be used with nested namespaces.
 
 ### Propagating labels
 

--- a/vault/client.go
+++ b/vault/client.go
@@ -37,6 +37,8 @@ type Client struct {
 	requestToken RequestToken
 	// vault namespace
 	rootVaultNamespace string
+	// restrict the operator to the Vault namespace set in the rootVaultNamespace field
+	restrictNamespace bool
 	// failedRenewTokenAttempts is the number of failed renew token attempts, if the renew token function fails 5 times
 	// the liveness probe will fail, to force a restart of the operator.
 	failedRenewTokenAttempts int
@@ -99,6 +101,10 @@ func (c *Client) GetHealth(threshold int) error {
 	}
 
 	return nil
+}
+
+func (c *Client) IsNamespaceRestricted() (bool, string) {
+	return c.restrictNamespace, c.rootVaultNamespace
 }
 
 // GetSecret returns the value for a given secret.

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -124,6 +124,11 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 		return nil, err
 	}
 
+	vaultRestrictNamespace, err := strconv.ParseBool(os.Getenv("VAULT_RESTRICT_NAMESPACE"))
+	if err != nil {
+		vaultRestrictNamespace = false
+	}
+
 	// Check which authentication method should be used.
 	if vaultAuthMethod == "token" {
 		// Check the required token and the provided lease duration for the
@@ -175,6 +180,7 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 			tokenRenewalInterval:      tokenRenewalInterval,
 			tokenRenewalRetryInterval: tokenRenewalRetryInterval,
 			rootVaultNamespace:        vaultNamespace,
+			restrictNamespace:         vaultRestrictNamespace,
 			pkiRenew:                  pkiRenew,
 		}, nil
 	}
@@ -242,6 +248,7 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 			tokenRenewalInterval:      tokenRenewalInterval,
 			tokenRenewalRetryInterval: tokenRenewalRetryInterval,
 			rootVaultNamespace:        vaultNamespace,
+			restrictNamespace:         vaultRestrictNamespace,
 			pkiRenew:                  pkiRenew,
 		}, nil
 	}
@@ -307,6 +314,7 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 			tokenRenewalRetryInterval: tokenRenewalRetryInterval,
 			tokenMaxTTL:               tokenMaxTTL,
 			rootVaultNamespace:        vaultNamespace,
+			restrictNamespace:         vaultRestrictNamespace,
 			requestToken: func(c *Client) error {
 				secret, err := apiClient.Logical().Write(appRolePath+"/login", data)
 				if err != nil {
@@ -375,6 +383,7 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 			tokenRenewalRetryInterval: tokenRenewalRetryInterval,
 			tokenMaxTTL:               tokenMaxTTL,
 			rootVaultNamespace:        vaultNamespace,
+			restrictNamespace:         vaultRestrictNamespace,
 			requestToken: func(c *Client) error {
 				secret, err := apiClient.Logical().Write(userPassLoginPath, data)
 				if err != nil {
@@ -466,6 +475,7 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 			tokenRenewalInterval:      tokenRenewalInterval,
 			tokenRenewalRetryInterval: tokenRenewalRetryInterval,
 			rootVaultNamespace:        vaultNamespace,
+			restrictNamespace:         vaultRestrictNamespace,
 			pkiRenew:                  pkiRenew,
 		}, nil
 
@@ -637,6 +647,7 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 			tokenRenewalInterval:      tokenRenewalInterval,
 			tokenRenewalRetryInterval: tokenRenewalRetryInterval,
 			rootVaultNamespace:        vaultNamespace,
+			restrictNamespace:         vaultRestrictNamespace,
 			tokenMaxTTL:               tokenMaxTTL,
 			requestToken: func(c *Client) error {
 				data, err := awsLoginDataFunc()
@@ -777,6 +788,7 @@ func CreateClient(vaultKubernetesRole string) (*Client, error) {
 			tokenRenewalInterval:      tokenRenewalInterval,
 			tokenRenewalRetryInterval: tokenRenewalRetryInterval,
 			rootVaultNamespace:        vaultNamespace,
+			restrictNamespace:         vaultRestrictNamespace,
 			requestToken: func(c *Client) error {
 				data, err := gcpLoginDataFunc()
 				if err != nil {


### PR DESCRIPTION
It is now possible to restrict the operator to a specific Vault Namespace. When the `VAULT_RESTRICT_NAMESPACE` environment variable is set to `true` the operator only reconciles secrets where the `spec.vaultNamespace` field is the same as the `VAULT_NAMESPACE` environment variable. VaultSecrets with another `spec.vaultNamespace` value will be ignored.

When this feature is enabled the operator can not be used with nested Vault Namespaces.

Closes #234