### PR TITLE
Fix Used Vault Namespace for Restrict Namespace Feature

### DIFF
--- a/vault/client.go
+++ b/vault/client.go
@@ -122,7 +122,7 @@ func (c *Client) GetSecret(secretEngine string, path string, keys []string, vers
 	// already failed.
 	if c.rootVaultNamespace != "" {
 		log.WithValues("rootVaultNamespace", c.rootVaultNamespace, "vaultNamespace", vaultNamespace).Info(fmt.Sprintf("Use Vault Namespace to read secret %s", path))
-		if vaultNamespace != "" {
+		if vaultNamespace != "" && !c.restrictNamespace {
 			c.client.SetNamespace(c.rootVaultNamespace + "/" + vaultNamespace)
 		} else {
 			c.client.SetNamespace(c.rootVaultNamespace)


### PR DESCRIPTION
When the `VAULT_RESTRICT_NAMESPACE` environment variable is set and the corresponding feature is enabled, the Vault namespace was not correctly set. This should now be fixed, so that when the feature is enabled only the root namespace will be used but not the Vault namespace from the secret.

Fixes #234