### PR TITLE
Fix null and empty object comparison

### DIFF
--- a/controllers/vaultsecret_controller.go
+++ b/controllers/vaultsecret_controller.go
@@ -175,7 +175,7 @@ func (r *VaultSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 		// Requeue before expiration
 		log.Info(fmt.Sprintf("Certificate will expire on %s", expiration.String()))
-		ra := expiration.Sub(time.Now()) - vaultClient.GetPKIRenew()
+		ra := time.Until(*expiration) - vaultClient.GetPKIRenew()
 		if ra <= 0 {
 			reconcileResult.Requeue = true
 		} else {
@@ -409,7 +409,7 @@ func newSecretForCR(cr *ricobergerdev1alpha1.VaultSecret, data map[string][]byte
 		for k, v := range cr.Spec.Templates {
 			templated, err := runTemplate(cr, v, data)
 			if err != nil {
-				return nil, fmt.Errorf("Template ERROR: %w", err)
+				return nil, fmt.Errorf("template ERROR: %w", err)
 			}
 			newdata[k] = templated
 		}

--- a/controllers/vaultsecret_controller.go
+++ b/controllers/vaultsecret_controller.go
@@ -394,16 +394,6 @@ func templatingFunctions() template.FuncMap {
 // newSecretForCR returns a secret with the same name/namespace as the CR. The secret will include all labels and
 // annotations from the CR.
 func newSecretForCR(cr *ricobergerdev1alpha1.VaultSecret, data map[string][]byte) (*corev1.Secret, error) {
-	labels := map[string]string{}
-	for k, v := range cr.ObjectMeta.Labels {
-		labels[k] = v
-	}
-
-	annotations := map[string]string{}
-	for k, v := range cr.ObjectMeta.Annotations {
-		annotations[k] = v
-	}
-
 	if cr.Spec.Templates != nil {
 		newdata := make(map[string][]byte)
 		for k, v := range cr.Spec.Templates {
@@ -420,8 +410,8 @@ func newSecretForCR(cr *ricobergerdev1alpha1.VaultSecret, data map[string][]byte
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        cr.Name,
 			Namespace:   cr.Namespace,
-			Labels:      labels,
-			Annotations: annotations,
+			Labels:      cr.ObjectMeta.Labels,
+			Annotations: cr.ObjectMeta.Annotations,
 		},
 		Data: data,
 		Type: cr.Spec.Type,


### PR DESCRIPTION
Fixes #273

We found that if the VaultSecret _without_ label, the corresponding k8s secret keeps [updating](https://github.com/ricoberger/vault-secrets-operator/blob/3efc8f70abdce459164f08c30a97c045aabca679/controllers/vaultsecret_controller.go#L247) because the two secrets labels are not the same. It's because existing k8s secret labels is null, however, the k8s secret labels generated from [newSecretForCR](https://github.com/ricoberger/vault-secrets-operator/blob/3efc8f70abdce459164f08c30a97c045aabca679/controllers/vaultsecret_controller.go#L396) is an empty object.

The generated k8s secret labels and annotations are directly inherited from the VaultSecret CR, so it does not require to loop it and copy it again.

Also, we fix the go-staticcheck warnings that
1. should use time.Until instead of t.Sub(time.Now())
2. error strings should not be capitalized