### PR TITLE
Add GitHub Container Registry

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -41,6 +41,13 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and Push Docker Image
         id: docker_build
         uses: docker/build-push-action@v6
@@ -49,4 +56,8 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
-          tags: ricoberger/vault-secrets-operator:${{ env.TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ env.TAG }}
+            ricoberger/vault-secrets-operator:${{ env.TAG }}

--- a/charts/README.md
+++ b/charts/README.md
@@ -4,8 +4,8 @@
 | ----- | ----------- | ------- |
 | `replicaCount` | Number of replications which should be created. | `1` |
 | `deploymentStrategy` | Deployment strategy which should be used. | `{}` |
-| `image.repository` | The repository of the Docker image. | `ricoberger/vault-secrets-operator` |
-| `image.tag` | The tag of the Docker image which should be used. | `v1.24.6` |
+| `image.repository` | The repository of the Docker image. | `ghcr.io/ricoberger/vault-secrets-operator` |
+| `image.tag` | The tag of the Docker image which should be used. | `v1.25.0` |
 | `image.digest` | The image digest of the Docker image which should be used | `""` |
 | `image.pullPolicy` | The pull policy for the Docker image, | `IfNotPresent` |
 | `image.volumeMounts` | Mount additional volumns to the container. | `[]` |

--- a/charts/vault-secrets-operator/Chart.yaml
+++ b/charts/vault-secrets-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v1.24.6
+appVersion: v1.25.0
 description: Create Kubernetes secrets from Vault for a secure GitOps based workflow.
 home: https://github.com/ricoberger/vault-secrets-operator
 icon: https://raw.githubusercontent.com/ricoberger/vault-secrets-operator/main/assets/logo.png
@@ -7,4 +7,4 @@ maintainers:
   - name: Rico Berger
     url: https://ricoberger.de
 name: vault-secrets-operator
-version: 2.5.12
+version: 2.6.0

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -2,8 +2,8 @@ replicaCount: 1
 deploymentStrategy: {}
 
 image:
-  repository: ricoberger/vault-secrets-operator
-  tag: v1.24.6
+  repository: ghcr.io/ricoberger/vault-secrets-operator
+  tag: v1.25.0
   # digest: sha256:7246830da1852a7417cccc1092beecdf524d9eb9fb7b29aabcf10796cccb3def
 
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Add the Docker image to the GitHub Container Registry as alternative to DockerHub and make GHCR the default in the Helm chart.

This commit also adds the `cache-from` and `cache-to` parameters to the GitHub Action to build the Docker image.