### PR TITLE
Remove `linux/386` as Supported Platform

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -1,3 +1,4 @@
+---
 name: Continuous Delivery
 
 on:
@@ -55,7 +56,7 @@ jobs:
           push: true
           context: .
           file: ./Dockerfile
-          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
+          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.4 as builder
+FROM golang:1.23.4 AS builder
 WORKDIR /workspace
 COPY go.mod go.sum /workspace/
 RUN go mod download


### PR DESCRIPTION
Remove `linux/386` as supported platform. In #293 we switched to the distroless image, which doesn't support the platform.