### PR TITLE
fix(pki): skip re-issuing certificates that are still valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ workflow the Vault Secrets Operator can be used as replacement for this.
 ## Installation
 
 The Vault Secrets Operator can be installed via Helm. A list of all configurable
-values can be found [here](./charts/vault-secrets-operator/values.yaml). The chart assumes a vault server
-running at `http://vault:8200`, but can be overidden by specifying
-`--set vault.address=https://vault.example.com`
+values can be found [here](./charts/vault-secrets-operator/values.yaml). The
+chart assumes a vault server running at `http://vault:8200`, but can be
+overidden by specifying `--set vault.address=https://vault.example.com`
 
 ```sh
 helm upgrade --install vault-secrets-operator oci://ghcr.io/ricoberger/charts/vault-secrets-operator --version <VERSION>
@@ -726,6 +726,14 @@ The following fields are available:
 Certificate are renewed before expiration. You can set how long before
 expiration you want to renew by setting the `VAULT_PKI_RENEW` environment
 variable. The default is 1 hour.
+
+The operator only issues a new certificate when the Secret does not yet exist or
+when the certificate currently stored in the Secret expires within the
+`VAULT_PKI_RENEW` window. If the existing certificate is still valid (its
+remaining lifetime is larger than `VAULT_PKI_RENEW`), reconciliations - for
+example after an operator restart or a leader failover - leave the Secret
+untouched. This prevents unnecessary Secret updates which could otherwise
+trigger rollout restarts of workloads referencing the Secret.
 
 ### Using specific Vault Role for secrets
 

--- a/internal/controller/vaultsecret_controller.go
+++ b/internal/controller/vaultsecret_controller.go
@@ -3,6 +3,8 @@ package controller
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"os"
 	"reflect"
@@ -210,6 +212,41 @@ func (r *VaultSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			log.Error(err, "Resource validation failed")
 			r.updateConditions(ctx, instance, conditionReasonInvalidResource, err.Error(), metav1.ConditionFalse)
 			return ctrl.Result{}, err
+		}
+
+		// Before issuing a new certificate we check if the Secret already
+		// exists and contains a certificate which is still valid. If the
+		// remaining lifetime of the existing certificate is larger than the
+		// configured renew window (VAULT_PKI_RENEW), we skip issuing a new
+		// certificate. This avoids unnecessary updates of the Kubernetes Secret
+		// on every reconcile (e.g. after an operator restart or leader
+		// failover), which could trigger unwanted rollout restarts of workloads
+		// referencing the Secret.
+		existing := &corev1.Secret{}
+		err = r.Get(ctx, types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, existing)
+		if err != nil && !errors.IsNotFound(err) {
+			log.Error(err, "Could not get secret")
+			r.updateConditions(ctx, instance, conditionReasonFetchFailed, err.Error(), metav1.ConditionFalse)
+			return ctrl.Result{}, err
+		}
+
+		if err == nil {
+			if certExpiration, ok := certificateExpiration(existing.Data); ok {
+				renewAfter := time.Until(certExpiration) - vaultClient.GetPKIRenew()
+				if renewAfter > 0 {
+					// The existing certificate is still valid and outside the
+					// renew window, so we leave the existing Secret untouched.
+					// We mirror the behaviour of the "no change" path below to
+					// avoid unnecessary status updates and requeue shortly
+					// before the certificate needs to be renewed.
+					log.Info("Skip updating a Secret cause the certificate is still valid", "Secret.Namespace", instance.Namespace, "Secret.Name", instance.Name)
+					log.Info(fmt.Sprintf("Certificate will expire on %s and will be renewed on %s", certExpiration.String(), time.Now().Add(renewAfter).String()))
+					reconcileResult.RequeueAfter = renewAfter
+					vaultSecretsReconciliationsTotal.WithLabelValues(instance.Namespace, instance.Name, string(metav1.ConditionTrue)).Inc()
+					vaultSecretsReconciliationStatus.WithLabelValues(instance.Namespace, instance.Name).Set(1)
+					return reconcileResult, nil
+				}
+			}
 		}
 
 		var expiration *time.Time
@@ -474,4 +511,44 @@ func mergeSecretData(newSecret, foundSecret *corev1.Secret) *corev1.Secret {
 	}
 
 	return newSecret
+}
+
+// certificateExpiration parses the certificates contained in the provided
+// Secret data and returns the expiration date (NotAfter) of the certificate
+// which expires first. For a Secret created from Vault's PKI engine this is the
+// leaf certificate. All data values are scanned so that the function also works
+// when the certificate was moved into a different key via templates. The
+// returned boolean is false when no certificate could be found, e.g. when the
+// Secret does not (yet) contain a certificate or when a template transformed it
+// into a format which can not be parsed.
+func certificateExpiration(data map[string][]byte) (time.Time, bool) {
+	var expiration time.Time
+	found := false
+
+	for _, value := range data {
+		rest := value
+		for {
+			var block *pem.Block
+			block, rest = pem.Decode(rest)
+			if block == nil {
+				break
+			}
+
+			if block.Type != "CERTIFICATE" {
+				continue
+			}
+
+			cert, err := x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				continue
+			}
+
+			if !found || cert.NotAfter.Before(expiration) {
+				expiration = cert.NotAfter
+				found = true
+			}
+		}
+	}
+
+	return expiration, found
 }

--- a/internal/controller/vaultsecret_controller_test.go
+++ b/internal/controller/vaultsecret_controller_test.go
@@ -1,0 +1,123 @@
+package controller
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+)
+
+// testCertPEM generates a self-signed certificate which expires at notAfter and
+// returns it as a PEM encoded byte slice.
+func testCertPEM(t *testing.T, commonName string, notAfter time.Time) []byte {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     notAfter,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// TestCertificateExpiration verifies that certificateExpiration extracts the
+// expiration date of the certificate which expires first from the Secret data.
+func TestCertificateExpiration(t *testing.T) {
+	leaf := time.Now().Add(48 * time.Hour).Truncate(time.Second)
+	ca := time.Now().Add(720 * time.Hour).Truncate(time.Second)
+
+	leafPEM := testCertPEM(t, "leaf", leaf)
+	caPEM := testCertPEM(t, "ca", ca)
+
+	t.Run("single certificate", func(t *testing.T) {
+		got, ok := certificateExpiration(map[string][]byte{
+			"certificate": leafPEM,
+		})
+		if !ok {
+			t.Fatal("expected a certificate to be found")
+		}
+		if !got.Equal(leaf) {
+			t.Errorf("expiration = %s, want %s", got, leaf)
+		}
+	})
+
+	t.Run("leaf and ca in separate keys returns earliest", func(t *testing.T) {
+		got, ok := certificateExpiration(map[string][]byte{
+			"certificate": leafPEM,
+			"issuing_ca":  caPEM,
+			"private_key": []byte("not a certificate"),
+		})
+		if !ok {
+			t.Fatal("expected a certificate to be found")
+		}
+		if !got.Equal(leaf) {
+			t.Errorf("expiration = %s, want %s (the leaf)", got, leaf)
+		}
+	})
+
+	t.Run("certificate chain in a single value returns earliest", func(t *testing.T) {
+		chain := append(append([]byte{}, caPEM...), leafPEM...)
+		got, ok := certificateExpiration(map[string][]byte{
+			"tls.crt": chain,
+		})
+		if !ok {
+			t.Fatal("expected a certificate to be found")
+		}
+		if !got.Equal(leaf) {
+			t.Errorf("expiration = %s, want %s (the leaf)", got, leaf)
+		}
+	})
+
+	t.Run("certificate moved to a custom key via template", func(t *testing.T) {
+		got, ok := certificateExpiration(map[string][]byte{
+			"my-custom-key": leafPEM,
+		})
+		if !ok {
+			t.Fatal("expected a certificate to be found")
+		}
+		if !got.Equal(leaf) {
+			t.Errorf("expiration = %s, want %s", got, leaf)
+		}
+	})
+
+	t.Run("no certificate present", func(t *testing.T) {
+		if _, ok := certificateExpiration(map[string][]byte{
+			"username": []byte("admin"),
+			"password": []byte("s3cr3t"),
+		}); ok {
+			t.Error("expected no certificate to be found")
+		}
+	})
+
+	t.Run("private key only", func(t *testing.T) {
+		keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("dummy")})
+		if _, ok := certificateExpiration(map[string][]byte{
+			"private_key": keyPEM,
+		}); ok {
+			t.Error("expected no certificate to be found")
+		}
+	})
+
+	t.Run("empty data", func(t *testing.T) {
+		if _, ok := certificateExpiration(map[string][]byte{}); ok {
+			t.Error("expected no certificate to be found")
+		}
+	})
+}


### PR DESCRIPTION
The PKI engine issued a new certificate on every reconcile, including
after operator restarts or leader failover. This always changed the
Kubernetes Secret data (new cert/key/serial), which could trigger broad
rollout-restart cascades for workloads that restart on Secret changes.

Before issuing, the operator now reads the existing Secret and parses the
stored certificate. If its remaining lifetime is larger than the
VAULT_PKI_RENEW window, issuing is skipped and the Secret is left
untouched, requeuing shortly before renewal is due. VAULT_PKI_RENEW
previously only scheduled the next requeue and never gated issuance.

The certificate is located by scanning all Secret data values for PEM
CERTIFICATE blocks, so it also works when templates move the certificate
into a custom key or concatenate a chain.

Closes #367

