### PR TITLE
feat: watch namespaces by namespace label selector

### DIFF
--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -70,6 +70,10 @@ spec:
             {{- else }}
               value: ""
             {{- end }}
+            {{- if and .Values.vault.namespaceLabelSelector (not .Values.rbac.namespaced) }}
+            - name: WATCH_NAMESPACE_LABEL_SELECTOR
+              value: {{ .Values.vault.namespaceLabelSelector | quote }}
+            {{- end }}
             {{- if .Values.vault.address }}
             - name: VAULT_ADDRESS
               value: {{ .Values.vault.address | quote }}

--- a/charts/vault-secrets-operator/templates/role.yaml
+++ b/charts/vault-secrets-operator/templates/role.yaml
@@ -38,6 +38,18 @@ rules:
   verbs:
   - create
   - patch
+{{- if not .Values.rbac.namespaced }}
+# Required by WATCH_NAMESPACE_LABEL_SELECTOR to discover namespaces by label.
+# Namespaces are cluster-scoped, so this is only granted for the ClusterRole.
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}
 - apiGroups:
   - ""
   resources:

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -85,6 +85,11 @@ environmentVars:
 ## comma separated list via the namespaces value. If the value is empty the
 ## operator will watch all namespaces. If the value is empty and rbac.namespaced
 ## is set to true, then the namespace of the release will be used.
+## The namespaceLabelSelector value additionally watches every namespace whose
+## labels match a standard Kubernetes label selector (e.g. "team=platform" or
+## "env in (prod,staging)"). It combines with the namespaces value using OR
+## semantics and picks up matching namespaces dynamically. It requires the
+## cluster-wide ClusterRole (rbac.namespaced=false).
 vault:
   address: ""
   header: ""
@@ -105,6 +110,7 @@ vault:
   gcpRole: vault-secrets-operator
   reconciliationTime: 0
   namespaces: ""
+  namespaceLabelSelector: ""
 
 rbac:
   create: true

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -74,6 +74,25 @@ func main() {
 		setupLog.Error(err, "unable to get WatchNamespace, the manager will watch and manage resources in all namespaces")
 	}
 
+	labelSelector := os.Getenv("WATCH_NAMESPACE_LABEL_SELECTOR")
+
+	// Normalize the comma-separated namespace list (e.g. "ns1, ns2").
+	space := regexp.MustCompile(`\s+`)
+	var namespaceList []string
+	if watchNamespace != "" {
+		for _, ns := range strings.Split(space.ReplaceAllString(watchNamespace, ""), ",") {
+			if ns != "" {
+				namespaceList = append(namespaceList, ns)
+			}
+		}
+	}
+
+	nsFilter, err := controller.NewNamespaceFilter(namespaceList, labelSelector)
+	if err != nil {
+		setupLog.Error(err, "invalid WATCH_NAMESPACE_LABEL_SELECTOR")
+		os.Exit(1)
+	}
+
 	options := ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
@@ -87,19 +106,21 @@ func main() {
 		LeaderElectionID:       "vaultsecretsoperator.ricoberger.de",
 	}
 
-	// Add support for MultiNamespace set in WATCH_NAMESPACE (e.g ns1,ns2)
-	if watchNamespace != "" {
+	// reconcilerFilter is non-nil only when a label selector is configured; in
+	// that mode the cache is cluster-wide and the reconciler filters namespaces.
+	var reconcilerFilter *controller.NamespaceFilter
+
+	switch {
+	case nsFilter.UsesLabelSelector():
+		setupLog.Info("manager set up with namespace label selector",
+			"namespaces", watchNamespace, "labelSelector", labelSelector)
+		reconcilerFilter = nsFilter
+	case len(namespaceList) > 0:
+		// Add support for MultiNamespace set in WATCH_NAMESPACE (e.g ns1,ns2)
 		setupLog.Info("manager set up with multiple namespaces", "namespaces", watchNamespace)
 
-		// remove whitespaces (e.g. WATCH_NAMESPACE=ns1, ns2)
-		space := regexp.MustCompile(`\s+`)
-		watchNamespace = space.ReplaceAllString(watchNamespace, "")
-
-		// split namespaces and setup cache
-		namespaces := make(map[string]cache.Config)
-		watchNamespaces := strings.SplitSeq(watchNamespace, ",")
-
-		for ns := range watchNamespaces {
+		namespaces := make(map[string]cache.Config, len(namespaceList))
+		for _, ns := range namespaceList {
 			namespaces[ns] = cache.Config{}
 		}
 
@@ -116,8 +137,9 @@ func main() {
 	}
 
 	if err = (&controller.VaultSecretReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:          mgr.GetClient(),
+		Scheme:          mgr.GetScheme(),
+		NamespaceFilter: reconcilerFilter,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VaultSecret")
 		os.Exit(1)

--- a/internal/controller/namespace_filter.go
+++ b/internal/controller/namespace_filter.go
@@ -1,0 +1,54 @@
+package controller
+
+import "k8s.io/apimachinery/pkg/labels"
+
+// NamespaceFilter decides whether a namespace should be watched. A namespace
+// is selected when its name is in the explicit list OR its labels match the
+// label selector (OR / union semantics).
+type NamespaceFilter struct {
+	names    map[string]struct{}
+	selector labels.Selector
+}
+
+// NewNamespaceFilter builds a filter from an explicit namespace list and a
+// standard Kubernetes label selector string. An empty labelSelector means no
+// selector; an invalid one returns an error.
+func NewNamespaceFilter(namespaces []string, labelSelector string) (*NamespaceFilter, error) {
+	f := &NamespaceFilter{names: make(map[string]struct{}, len(namespaces))}
+	for _, ns := range namespaces {
+		if ns != "" {
+			f.names[ns] = struct{}{}
+		}
+	}
+	if labelSelector != "" {
+		sel, err := labels.Parse(labelSelector)
+		if err != nil {
+			return nil, err
+		}
+		f.selector = sel
+	}
+	return f, nil
+}
+
+// Enabled reports whether any namespace restriction is configured.
+func (f *NamespaceFilter) Enabled() bool {
+	return len(f.names) > 0 || f.selector != nil
+}
+
+// UsesLabelSelector reports whether a label selector is configured. When true
+// the cache must run cluster-wide so labels can be evaluated dynamically.
+func (f *NamespaceFilter) UsesLabelSelector() bool {
+	return f.selector != nil
+}
+
+// Matches reports whether the namespace with the given name and labels should
+// be watched.
+func (f *NamespaceFilter) Matches(name string, nsLabels map[string]string) bool {
+	if !f.Enabled() {
+		return true
+	}
+	if _, ok := f.names[name]; ok {
+		return true
+	}
+	return f.selector != nil && f.selector.Matches(labels.Set(nsLabels))
+}

--- a/internal/controller/namespace_filter_test.go
+++ b/internal/controller/namespace_filter_test.go
@@ -1,0 +1,105 @@
+package controller
+
+import "testing"
+
+func TestNamespaceFilter(t *testing.T) {
+	tests := []struct {
+		name          string
+		namespaces    []string
+		labelSelector string
+		wantErr       bool
+		enabled       bool
+		usesSelector  bool
+		matchName     string
+		matchLabels   map[string]string
+		wantMatch     bool
+	}{
+		{
+			name:      "disabled matches everything",
+			enabled:   false,
+			matchName: "anything",
+			wantMatch: true,
+		},
+		{
+			name:       "explicit name in list matches",
+			namespaces: []string{"team-a", "team-b"},
+			enabled:    true,
+			matchName:  "team-a",
+			wantMatch:  true,
+		},
+		{
+			name:       "explicit name not in list does not match",
+			namespaces: []string{"team-a"},
+			enabled:    true,
+			matchName:  "team-c",
+			wantMatch:  false,
+		},
+		{
+			name:          "label selector matches",
+			labelSelector: "watch=true",
+			enabled:       true,
+			usesSelector:  true,
+			matchName:     "team-x",
+			matchLabels:   map[string]string{"watch": "true"},
+			wantMatch:     true,
+		},
+		{
+			name:          "label selector does not match",
+			labelSelector: "watch=true",
+			enabled:       true,
+			usesSelector:  true,
+			matchName:     "team-x",
+			matchLabels:   map[string]string{"watch": "false"},
+			wantMatch:     false,
+		},
+		{
+			name:          "OR union: name matches even when label does not",
+			namespaces:    []string{"team-a"},
+			labelSelector: "watch=true",
+			enabled:       true,
+			usesSelector:  true,
+			matchName:     "team-a",
+			matchLabels:   map[string]string{"watch": "false"},
+			wantMatch:     true,
+		},
+		{
+			name:          "OR union: label matches even when name is absent",
+			namespaces:    []string{"team-a"},
+			labelSelector: "watch=true",
+			enabled:       true,
+			usesSelector:  true,
+			matchName:     "team-z",
+			matchLabels:   map[string]string{"watch": "true"},
+			wantMatch:     true,
+		},
+		{
+			name:          "invalid selector errors",
+			labelSelector: "!!!bad",
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := NewNamespaceFilter(tt.namespaces, tt.labelSelector)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := f.Enabled(); got != tt.enabled {
+				t.Errorf("Enabled() = %v, want %v", got, tt.enabled)
+			}
+			if got := f.UsesLabelSelector(); got != tt.usesSelector {
+				t.Errorf("UsesLabelSelector() = %v, want %v", got, tt.usesSelector)
+			}
+			if got := f.Matches(tt.matchName, tt.matchLabels); got != tt.wantMatch {
+				t.Errorf("Matches(%q, %v) = %v, want %v", tt.matchName, tt.matchLabels, got, tt.wantMatch)
+			}
+		})
+	}
+}

--- a/internal/controller/vaultsecret_controller.go
+++ b/internal/controller/vaultsecret_controller.go
@@ -23,12 +23,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logr "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const (
@@ -70,6 +73,11 @@ var (
 type VaultSecretReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+	// NamespaceFilter, when non-nil, restricts reconciliation to namespaces
+	// selected by name or label. It is only set when a label selector is
+	// configured (which forces a cluster-wide cache); otherwise it is nil and
+	// behavior is unchanged.
+	NamespaceFilter *NamespaceFilter
 }
 
 func init() {
@@ -85,6 +93,7 @@ func init() {
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -142,6 +151,19 @@ func (r *VaultSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 
 		return ctrl.Result{}, nil
+	}
+
+	// Skip VaultSecrets whose namespace is no longer selected for watching.
+	// Deletion is handled above, so finalizers are always removed regardless of
+	// namespace selection.
+	if r.NamespaceFilter != nil {
+		ns := &corev1.Namespace{}
+		if err := r.Get(ctx, types.NamespacedName{Name: instance.Namespace}, ns); err != nil {
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+		if !r.NamespaceFilter.Matches(instance.Namespace, ns.Labels) {
+			return ctrl.Result{}, nil
+		}
 	}
 
 	// Add the vaultsecretsFinalizer to the VaultSecret. The finilizer is needed
@@ -384,12 +406,66 @@ func ignorePredicate() predicate.Predicate {
 	}
 }
 
+// mapNamespaceToVaultSecrets enqueues every VaultSecret in a namespace when
+// that namespace becomes (or remains) selected, so label changes are picked up
+// dynamically.
+func (r *VaultSecretReconciler) mapNamespaceToVaultSecrets(ctx context.Context, obj client.Object) []reconcile.Request {
+	if r.NamespaceFilter == nil || !r.NamespaceFilter.Matches(obj.GetName(), obj.GetLabels()) {
+		return nil
+	}
+	list := &ricobergerdev1alpha1.VaultSecretList{}
+	if err := r.List(ctx, list, client.InNamespace(obj.GetName())); err != nil {
+		return nil
+	}
+	reqs := make([]reconcile.Request, 0, len(list.Items))
+	for i := range list.Items {
+		reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{
+			Namespace: list.Items[i].Namespace,
+			Name:      list.Items[i].Name,
+		}})
+	}
+	return reqs
+}
+
+// namespaceBecameMatching admits only namespace events that bring a namespace
+// into the watched set: a namespace created already matching, or updated from
+// non-matching to matching. Namespaces that already matched are handled by the
+// primary VaultSecret watch, so re-enqueuing them here only causes redundant
+// reconciles (and status-update races), which this predicate avoids.
+func (r *VaultSecretReconciler) namespaceBecameMatching() predicate.Predicate {
+	matches := func(o client.Object) bool {
+		return r.NamespaceFilter != nil && r.NamespaceFilter.Matches(o.GetName(), o.GetLabels())
+	}
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return matches(e.Object) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return !matches(e.ObjectOld) && matches(e.ObjectNew) },
+		DeleteFunc:  func(event.DeleteEvent) bool { return false },
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *VaultSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.NamespaceFilter == nil {
+		// No label selector configured: unchanged behavior.
+		return ctrl.NewControllerManagedBy(mgr).
+			For(&ricobergerdev1alpha1.VaultSecret{}).
+			Owns(&corev1.Secret{}).
+			WithEventFilter(ignorePredicate()).
+			Complete(r)
+	}
+
+	// Label selector configured: the cache is cluster-wide, so the Reconcile
+	// guard is the single source of truth for namespace selection. Here we only
+	// add a Namespace watch to pick up label changes dynamically. Per-watch
+	// predicates are used (instead of WithEventFilter) because ignorePredicate
+	// keys on generation, which namespaces do not bump on label changes.
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&ricobergerdev1alpha1.VaultSecret{}).
-		Owns(&corev1.Secret{}).
-		WithEventFilter(ignorePredicate()).
+		For(&ricobergerdev1alpha1.VaultSecret{}, builder.WithPredicates(ignorePredicate())).
+		Owns(&corev1.Secret{}, builder.WithPredicates(ignorePredicate())).
+		Watches(&corev1.Namespace{},
+			handler.EnqueueRequestsFromMapFunc(r.mapNamespaceToVaultSecrets),
+			builder.WithPredicates(r.namespaceBecameMatching())).
 		Complete(r)
 }
 


### PR DESCRIPTION
## Summary

Adds support for watching namespaces selected by a **namespace label selector** (e.g. `team=platform`, `env in (prod,staging)`), in addition to the existing explicit `WATCH_NAMESPACE` list.

New env var: `WATCH_NAMESPACE_LABEL_SELECTOR` (standard Kubernetes label selector syntax, parsed with `labels.Parse`).

## Combination semantics: OR (union)

`WATCH_NAMESPACE` and `WATCH_NAMESPACE_LABEL_SELECTOR` combine with **OR** — the operator watches the union of explicitly-listed namespaces and label-matched namespaces. Both empty → all namespaces (unchanged).

| `WATCH_NAMESPACE` | `WATCH_NAMESPACE_LABEL_SELECTOR` | Behavior |
|---|---|---|
| empty | empty | cluster-wide, no filtering (unchanged) |
| set | empty | efficient `cache.DefaultNamespaces` scoping (unchanged) |
| — | set | cluster-wide cache + reconcile-level filter (name ∪ label match) |

## Dynamic behavior

Namespaces matching the label are picked up **dynamically** — creating a namespace or adding the label later starts reconciliation without restarting the operator, via a `Namespace` watch that re-enqueues VaultSecrets on label change.

Because controller-runtime's cache scoping (`DefaultNamespaces`) cannot resolve namespaces by label and cannot change scope after build, enabling a label selector runs the cache **cluster-wide**; namespace selection is then enforced by a per-watch predicate + a `Reconcile` guard.

When a namespace stops matching, reconciliation stops but already-created child Secrets are **retained** (the delete path stays above the guard, so finalizers are always removed).