### PR TITLE
Add revisionHistoryLimit support for Deployment

### DIFF
--- a/charts/vault-secrets-operator/templates/deployment.yaml
+++ b/charts/vault-secrets-operator/templates/deployment.yaml
@@ -11,6 +11,9 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   {{- with .Values.deploymentStrategy }}
   strategy:
     {{- toYaml . | nindent 4 }}

--- a/charts/vault-secrets-operator/values.yaml
+++ b/charts/vault-secrets-operator/values.yaml
@@ -1,6 +1,13 @@
 replicaCount: 1
 deploymentStrategy: {}
 
+## The number of old ReplicaSets to retain for rollback. Defaults to the
+## Kubernetes-native default (10) when unset, so this is a no-op unless
+## overridden.
+## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy
+##
+revisionHistoryLimit: 10
+
 image:
   repository: ghcr.io/ricoberger/vault-secrets-operator
   ## Overrides the image tag whose default is the chart appVersion.


### PR DESCRIPTION
**Description**
In the current implementation, the operator Deployment doesn't set spec.revisionHistoryLimit, so it always falls back to the Kubernetes default (10) with no way to configure it. Old ReplicaSets from every past rollout are retained under that default, and on clusters where this Deployment (or Kubernetes workloads generally) is watched and reconciled by GitOps tooling like ArgoCD, each retained **stale ReplicaSet is extra object state** that has to be diffed on every sync pass. In environments running a **large number of ArgoCD Applications**, the accumulated stale-ReplicaSet history across many components adds measurable load to the ArgoCD application-controller and slows down sync/diff fleet-wide, not just for this component's own reconciliation.

**Remediation**
Adds a revisionHistoryLimit value to values.yaml (default 10, matching the current implicit Kubernetes default so behavior is unchanged unless overridden) and wires it into
templates/deployment.yaml under spec.revisionHistoryLimit, guarded so it's only set when explicitly configured. This lets operators lower the retained ReplicaSet history to reduce object count/GitOps sync load without giving up rollback capability entirely.

**Possible improvements**
None anticipated - this follows the standard Helm chart pattern for revisionHistoryLimit used across most charts and doesn't touch any other behavior.